### PR TITLE
Feature/add details components

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This library depends on a few external libraries. The following are installed as
 - [JQuery](https://jquery.com/)
 - [Lodash](https://lodash.com/)
 - [Momentjs](https://momentjs.com/)
+- [Visjs](https://visjs.org/)
 
 [Font Awesome 5](https://fontawesome.com/) is used for icon support. It must be included in your application.
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "bootstrap-vue": "^2.20.x",
     "jquery": "^3.5.x",
     "lodash": "^4.17.x",
-    "moment": "^2.22.1"
+    "moment": "^2.22.1",
+    "vis": "4.19.1"
   },
   "homepage": "https://github.com/observatorycontrolsystem/ocs-component-lib",
   "keywords": [

--- a/src/assets/css/visPlot.css
+++ b/src/assets/css/visPlot.css
@@ -1,0 +1,72 @@
+.vis-line-graph text{
+	display: none;
+	pointer-events: none;
+}
+
+.vis-point {
+	pointer-events: all;
+}
+
+.vis-item.vis-range{
+	border-radius: 0px;
+}
+
+div.vis-tooltip{
+    word-wrap: break-word;
+    max-width: 80em;
+    white-space: normal;
+}
+
+.legend-item {
+    width: 18px;
+    height: 12px;
+    display: inline-block;
+}
+
+.panel-default>.panel-heading:hover{
+	background-color: #dcdcdc;
+	border-color: #cfcfcf;
+}
+
+.panel-success>.panel-heading:hover{
+	background-color: #c1e2b3;
+	border-color: #b2dba1;
+}
+
+.panel-warning>.panel-heading:hover{
+	background-color: #f7ecb5;
+	border-color: #f5e79e;
+}
+
+.plot_controls {
+    position: absolute;
+    right: 0;
+    margin-right: 22px;
+    margin-top: 4px;
+    z-index: 9999;
+}
+
+.clickable-thumbnail {
+	display:block;
+	width: 100%;
+	height: 100%;
+}
+
+.clickable-thumbnail:visited, .clickable-thumbnail:link{
+	text-decoration: none;
+	color: lightgrey;
+}
+
+.clickable-thumbnail:hover{
+	color:white;
+}
+
+.width180 {
+	width: 180px;
+	font-size: 21px;
+}
+
+.width120 {
+	width: 120px;
+	font-size: 21px;
+}

--- a/src/components/Configurations/RequestConfigurationsDetail.vue
+++ b/src/components/Configurations/RequestConfigurationsDetail.vue
@@ -168,3 +168,8 @@ export default {
   }
 };
 </script>
+<style scoped>
+.no-top-border > tr > td {
+  border-top: none;
+}
+</style>

--- a/src/components/Observations/ObservationDetail.vue
+++ b/src/components/Observations/ObservationDetail.vue
@@ -1,0 +1,132 @@
+<template>
+  <div>
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Request</th>
+          <th>Site</th>
+          <th>Enclosure</th>
+          <th>Telescope</th>
+          <th>Start</th>
+          <th>End</th>
+          <th>State</th>
+          <th>Priority</th>
+          <th>Modified</th>
+          <th>Created</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <b-link v-if="requestLink.href" :href="requestLink.href" class="request-display-code">
+              {{ observation.request }}
+            </b-link>
+            <b-link v-else-if="requestLink.to" :to="requestLink.to" class="request-display-code">
+              {{ observation.request }}
+            </b-link>
+            <span v-else class="request-display-code">
+              {{ observation.request }}
+            </span>
+          </td>
+          <td>{{ observation.site }}</td>
+          <td>{{ observation.enclosure }}</td>
+          <td>{{ observation.telescope }}</td>
+          <td>{{ observation.start | formatDate }}</td>
+          <td>{{ observation.end | formatDate }}</td>
+          <td>{{ observation.state }}</td>
+          <td>{{ observation.priority }}</td>
+          <td>{{ observation.modified | formatDate }}</td>
+          <td>{{ observation.created | formatDate }}</td>
+        </tr>
+      </tbody>
+    </table>
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th colspan="4" style="border-right: 2px solid black">Config Status</th>
+          <th colspan="6">Summary</th>
+        </tr>
+        <tr>
+          <th>Id</th>
+          <th>Instrument</th>
+          <th>Guider</th>
+          <th style="border-right: 2px solid black">State</th>
+          <th>State</th>
+          <th>Start</th>
+          <th>End</th>
+          <th>Reason</th>
+          <th>Time</th>
+          <th>Events</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="cStatus in observation.configuration_statuses" :key="cStatus.id">
+          <td>{{ cStatus.id }}</td>
+          <td>{{ cStatus.instrument_name }}</td>
+          <td>{{ cStatus.guide_camera_name }}</td>
+          <td style="border-right: 2px solid black">{{ cStatus.state }}</td>
+          <template v-if="cStatus.summary">
+            <td>{{ cStatus.summary.state }}</td>
+            <td>{{ cStatus.summary.start | formatDate }}</td>
+            <td>{{ cStatus.summary.end | formatDate }}</td>
+            <td>{{ cStatus.summary.reason }}</td>
+            <td>{{ cStatus.summary.time_completed }}</td>
+            <td><a href="#" @click="openEvents(cStatus.summary.events)">View</a></td>
+          </template>
+          <template v-else>
+            <td colspan="6">No summary</td>
+          </template>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+<script>
+import _ from 'lodash';
+
+import { formatDate } from '@/util';
+
+export default {
+  name: 'ObservationDetail',
+  filters: {
+    formatDate(value) {
+      return formatDate(value);
+    }
+  },
+  props: {
+    observation: {
+      type: Object,
+      required: true
+    },
+    // Set `requestLink` to turn the displayed request ID into a link. Pass in an object with either { "href": "..." } specifying
+    // the "href" attribute for a normal <a> tag or { "to": ... } specifying a vue-router target route "to" attribute
+    // for the <router-link> tag.
+    requestLink: {
+      type: Object,
+      required: false,
+      default: () => {
+        return {};
+      },
+      validator: value => {
+        let hasHref = 'href' in value;
+        let hasTo = 'to' in value;
+        if (hasHref && hasTo) return false;
+        if (_.isEmpty(value)) return true;
+        return hasHref || hasTo;
+      }
+    }
+  },
+  methods: {
+    openEvents: function(events_text) {
+      var y = window.top.outerHeight / 2 + window.top.screenY - 300;
+      var x = window.top.outerWidth / 2 + window.top.screenX - 300;
+      var newWin = open(
+        '',
+        'Events',
+        'scrollbars=yes, toolbar=no, location=no, menubar=no, width=' + 600 + ', height=' + 600 + ', top=' + y + ', left=' + x
+      );
+      newWin.document.write('<pre>' + JSON.stringify(events_text, null, 2) + '</pre>');
+    }
+  }
+};
+</script>

--- a/src/components/Observations/ObservationDetail.vue
+++ b/src/components/Observations/ObservationDetail.vue
@@ -18,15 +18,7 @@
       <tbody>
         <tr>
           <td>
-            <b-link v-if="requestLink.href" :href="requestLink.href" class="request-display-code">
-              {{ observation.request }}
-            </b-link>
-            <b-link v-else-if="requestLink.to" :to="requestLink.to" class="request-display-code">
-              {{ observation.request }}
-            </b-link>
-            <span v-else class="request-display-code">
-              {{ observation.request }}
-            </span>
+            <text-display :link="requestLink" :text="observation.request | toString" text-classes="request-display-code" />
           </td>
           <td>{{ observation.site }}</td>
           <td>{{ observation.enclosure }}</td>
@@ -85,13 +77,20 @@
 import _ from 'lodash';
 
 import { formatDate } from '@/util';
+import { TextDisplay } from '@/components/Util';
 
 export default {
   name: 'ObservationDetail',
   filters: {
     formatDate(value) {
       return formatDate(value);
+    },
+    toString: function(value) {
+      return _.toString(value);
     }
+  },
+  components: {
+    TextDisplay
   },
   props: {
     observation: {
@@ -106,13 +105,6 @@ export default {
       required: false,
       default: () => {
         return {};
-      },
-      validator: value => {
-        let hasHref = 'href' in value;
-        let hasTo = 'to' in value;
-        if (hasHref && hasTo) return false;
-        if (_.isEmpty(value)) return true;
-        return hasHref || hasTo;
       }
     }
   },

--- a/src/components/Observations/index.js
+++ b/src/components/Observations/index.js
@@ -1,0 +1,3 @@
+import ObservationDetail from './ObservationDetail.vue';
+
+export { ObservationDetail };

--- a/src/components/Plots/AirmassPlot.vue
+++ b/src/components/Plots/AirmassPlot.vue
@@ -1,0 +1,220 @@
+<template>
+  <div ref="plot" class="airmassPlot">
+    <vis-plot-control v-show="showZoomControls" @plotZoom="plotZoom" />
+  </div>
+</template>
+<script>
+import vis from 'vis';
+import 'vis/dist/vis.css';
+import $ from 'jquery';
+import _ from 'lodash';
+import '@/assets/css/visPlot.css';
+
+import VisPlotControl from './VisPlotControl.vue';
+import { plotZoomMixin } from './visPlotMixins.js';
+
+export default {
+  name: 'AirmassPlot',
+  components: {
+    VisPlotControl
+  },
+  mixins: [plotZoomMixin],
+  props: {
+    // TODO: Add description of data
+    data: {
+      type: Object,
+      required: true
+    },
+    // Mapping of 3-letter site code to CSS color
+    siteCodeToColor: {
+      type: Object,
+      required: true
+    },
+    // Mapping of 3-letter site code to display name
+    siteCodeToName: {
+      type: Object,
+      required: true
+    },
+    showZoomControls: {
+      type: Boolean
+    },
+    alignleft: {
+      type: Boolean
+    }
+  },
+  data: function() {
+    let options = {
+      dataAxis: {
+        left: {
+          format: function(value) {
+            return Math.abs(value).toPrecision(2);
+          }
+        },
+        width: this.alignleft ? '129px' : ''
+      },
+      orientation: 'top',
+      legend: {
+        enabled: true,
+        left: {
+          visible: true,
+          position: 'bottom-right'
+        }
+      },
+      zoomKey: 'ctrlKey',
+      moment: function(date) {
+        return vis.moment(date).utc();
+      }
+    };
+    return {
+      options: options
+    };
+  },
+  computed: {
+    toVis: function() {
+      let plotSites = new vis.DataSet();
+      let visData = new vis.DataSet();
+      if (!$.isEmptyObject(this.data)) {
+        let i = 0;
+        let airmass_limit = this.data.airmass_limit;
+        for (let site in this.data.airmass_data) {
+          let airmasses = this.data.airmass_data[site]['airmasses'];
+          let airmass_times = this.data.airmass_data[site]['times'];
+          let p = 0;
+          let last_time = new Date(airmass_times[0] + 'Z');
+          let current_time = last_time;
+          plotSites.add({
+            id: i,
+            content: this.siteCodeToName[site],
+            options: {
+              drawPoints: {
+                enabled: true,
+                size: 9,
+                style: 'circle',
+                styles: 'stroke:' + this.siteCodeToColor[site] + '; fill: ' + this.siteCodeToColor[site] + '; visibility: hidden;'
+              },
+              excludeFromLegend: false
+            },
+            style: 'stroke: ' + this.siteCodeToColor[site] + ';'
+          });
+          for (p = 0; p < airmass_times.length; p++) {
+            current_time = new Date(airmass_times[p] + 'Z');
+            // This 16 is a magic number, greater than the spacing between datapoints to detect horizon split
+            if (Math.floor((current_time - last_time) / 1000.0 / 60.0) > 16.0) {
+              //another group is used for the case when the horizon is split in the >24 hour period, so we
+              //have separate time groups that are above the airmass threshold
+              i++;
+              plotSites.add({
+                id: i,
+                content: this.siteCodeToName[site],
+                options: {
+                  drawPoints: {
+                    enabled: true,
+                    size: 7,
+                    style: 'circle',
+                    styles: 'stroke:' + this.siteCodeToColor[site] + '; fill: ' + this.siteCodeToColor[site] + '; visibility: hidden;'
+                  },
+                  excludeFromLegend: true
+                },
+                style: 'stroke: ' + this.siteCodeToColor[site] + ';'
+              });
+            }
+            last_time = current_time;
+            visData.add([
+              {
+                x: airmass_times[p] + 'Z',
+                y: -airmasses[p],
+                group: i,
+                label: {
+                  content:
+                    'Site: ' +
+                    this.siteCodeToName[site] +
+                    '<br>Time: ' +
+                    airmass_times[p].replace('T', ' ') +
+                    '<br>Airmass: ' +
+                    airmasses[p].toFixed(2),
+                  className: 'graphtt'
+                }
+              }
+            ]);
+          }
+          i++;
+        }
+        // Now add a group for the airmass limit line
+        plotSites.add({
+          id: i,
+          content: 'limit',
+          options: {
+            drawPoints: { enabled: false },
+            excludeFromLegend: false
+          },
+          style: 'stroke: black;'
+        });
+        if (airmass_limit) {
+          let limitMin = new Date(visData.min('x')['x']);
+          limitMin.setMinutes(limitMin.getMinutes() - 30);
+          let limitMax = new Date(visData.max('x')['x']);
+          limitMax.setMinutes(limitMax.getMinutes() + 30);
+          visData.add([
+            { x: limitMin, y: -1 * airmass_limit, group: i },
+            { x: limitMax, y: -1 * airmass_limit, group: i }
+          ]);
+        }
+      }
+      return { datasets: visData, groups: plotSites };
+    }
+  },
+  watch: {
+    data: function() {
+      let datasets = this.toVis;
+      // Need to first zero out the items and groups or vis.js throws an error
+      this.plot.setItems(new vis.DataSet());
+      this.plot.setGroups(new vis.DataSet());
+      this.plot.setGroups(datasets.groups);
+      this.plot.setItems(datasets.datasets);
+      this.plot.fit();
+    }
+  },
+  mounted: function() {
+    this.plot = this.buildPlot();
+  },
+  methods: {
+    buildPlot: function() {
+      // Set a unique name for the plot element, since vis.js needs this to separate plots
+      this.$refs.plot.setAttribute('class', _.uniqueId(this.$refs.plot.className));
+      let plot = new vis.Graph2d(this.$refs.plot, new vis.DataSet([]), this.options);
+      let that = this;
+      plot.on('changed', function() {
+        $(that.$el)
+          .find('.vis-point')
+          .each(function() {
+            $(this).attr(
+              'title',
+              $(this)
+                .next()
+                .text()
+            );
+            $(this).attr(
+              'data-original-title',
+              $(this)
+                .next()
+                .text()
+            );
+            $(this).attr('data-html', 'true');
+            let label = $(this).next();
+            $(this).appendTo($(this).parent());
+            label.appendTo($(this).parent());
+          });
+        $(that.$el)
+          .find('.vis-legend svg path')
+          .each(function() {
+            $(this).appendTo($(this).parent());
+          });
+      });
+      plot.on('rangechanged', function() {
+        that.$emit('rangechanged', that.plot.getWindow());
+      });
+      return plot;
+    }
+  }
+};
+</script>

--- a/src/components/Plots/AirmassPlot.vue
+++ b/src/components/Plots/AirmassPlot.vue
@@ -211,6 +211,8 @@ export default {
           });
       });
       plot.on('rangechanged', function() {
+        // on rangechanged, the user of this component can call the .updateWindow() method provided by
+        // the plotZoomMixin mixin.
         that.$emit('rangechanged', that.plot.getWindow());
       });
       return plot;

--- a/src/components/Plots/AirmassPlot.vue
+++ b/src/components/Plots/AirmassPlot.vue
@@ -226,8 +226,8 @@ export default {
           });
       });
       plot.on('rangechanged', function() {
-        // on rangechanged, the user of this component can call the .updateWindow() method provided by
-        // the plotZoomMixin mixin.
+        // On rangechanged, the user of this component can call the .updateWindow() method on the
+        // component that is provided by the plotZoomMixin mixin.
         that.$emit('rangechanged', that.plot.getWindow());
       });
       return plot;

--- a/src/components/Plots/AirmassPlot.vue
+++ b/src/components/Plots/AirmassPlot.vue
@@ -20,7 +20,22 @@ export default {
   },
   mixins: [plotZoomMixin],
   props: {
-    // TODO: Add description of data
+    // Airmass data. Assuming there is visibility at a site with site code "abc", data is in the following form:
+    // {
+    //   "airmass_data": {
+    //     "abc": {
+    //       "times": [
+    //         "2021-02-10T03:08",
+    //         "2021-02-11T03:04"
+    //       ],
+    //       "airmasses": [
+    //         1.9937497463966114,
+    //         1.993729745536924
+    //       ]
+    //     }
+    //   },
+    //   "airmass_limit": 2.0
+    // }
     data: {
       type: Object,
       required: true

--- a/src/components/Plots/ObservationHistoryPlot.vue
+++ b/src/components/Plots/ObservationHistoryPlot.vue
@@ -214,7 +214,7 @@ export default {
   watch: {
     data: function() {
       let datasets = this.toVis;
-      //Need to first zero out the items and groups or vis.js throws an error
+      // Need to first zero out the items and groups or vis.js throws an error
       this.plot.setItems(new vis.DataSet());
       this.plot.setGroups(new vis.DataSet());
       this.plot.setGroups(datasets.groups);

--- a/src/components/Plots/ObservationHistoryPlot.vue
+++ b/src/components/Plots/ObservationHistoryPlot.vue
@@ -1,0 +1,288 @@
+<template>
+  <div>
+    <div ref="plot" class="observationHistoryPlot">
+      <vis-plot-control v-show="showZoomControls" @plotZoom="plotZoom" />
+    </div>
+    <div v-if="showLegend" class="observationHistoryPlotLegend text-center">
+      <ul class="list-inline mt-1">
+        <li class="list-inline-item">
+          <span class="legend-item CANCELED align-middle mb-1 mr-1" />
+          Superseded by new schedule
+        </li>
+        <li class="list-inline-item ml-3">
+          <span class="legend-item SCHEDULED align-middle mb-1 mr-1" />
+          Scheduled
+        </li>
+        <li class="list-inline-item ml-3">
+          <span class="legend-item NOT_ATTEMPTED align-middle mb-1 mr-1" />
+          Not Attempted
+        </li>
+        <li class="list-inline-item ml-3">
+          <span class="legend-item IN_PROGRESS align-middle mb-1 mr-1" />
+          In Progress
+        </li>
+        <li class="list-inline-item ml-3">
+          <span class="legend-item FAILED align-middle mb-1 mr-1" />
+          Failed
+        </li>
+        <li class="list-inline-item ml-3">
+          <span class="legend-item ABORTED align-middle mb-1 mr-1" />
+          Aborted
+        </li>
+        <li class="list-inline-item ml-3">
+          <span class="legend-item PARTIALLY-COMPLETED align-middle mb-1 mr-1" />
+          Partially Completed
+        </li>
+        <li class="list-inline-item ml-3">
+          <span class="legend-item COMPLETED align-middle mb-1 mr-1" />
+          Completed
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+<script>
+import vis from 'vis';
+import 'vis/dist/vis.css';
+import _ from 'lodash';
+
+import '@/assets/css/visPlot.css';
+import VisPlotControl from './VisPlotControl.vue';
+import { plotZoomMixin } from './visPlotMixins.js';
+
+export default {
+  name: 'ObservationHistoryPlot',
+  components: {
+    VisPlotControl
+  },
+  mixins: [plotZoomMixin],
+  props: {
+    // TODO: Describe data, including that the observation state colors can be overridden by applying classes that are the
+    // state
+    data: {
+      type: Array,
+      required: true
+    },
+    showZoomControls: {
+      type: Boolean
+    },
+    showLegend: {
+      type: Boolean
+    }
+  },
+  data: function() {
+    let options = {
+      groupOrder: 'content',
+      maxHeight: '450px',
+      minHeight: '120px',
+      align: 'right',
+      dataAttributes: ['toggle', 'html'],
+      selectable: false,
+      snap: null,
+      zoomKey: 'ctrlKey',
+      moment: function(date) {
+        return vis.moment(date).utc();
+      },
+      tooltip: {
+        overflowMethod: 'cap'
+      }
+    };
+    return {
+      options: options
+    };
+  },
+  computed: {
+    toVis: function() {
+      let visGroups = new vis.DataSet();
+      let visData = new vis.DataSet();
+      let timeline_min = 0;
+      let timeline_max = 0;
+      if (this.data.length > 0) {
+        let previousObservation = this.data[0];
+        let previousObservationIndex = 1;
+        let index = 0;
+        for (let i = 0; i < this.data.length; i++) {
+          let observation = this.data[i];
+          let state = observation.state;
+          if (state === 'PENDING') {
+            if (new Date(observation.end) > new Date()) {
+              state = 'SCHEDULED';
+            } else {
+              state = 'NOT_ATTEMPTED';
+            }
+          }
+          if (state != 'COMPLETED' && new Date(observation.end) < new Date() && observation.percent_completed > 0) {
+            state = 'PARTIALLY-COMPLETED';
+          }
+          observation.state = state;
+
+          if (_.isString(observation.fail_reason) && observation.fail_reason !== '') {
+            observation.fail_reason = '<br/>reason: ' + observation.fail_reason;
+          } else {
+            observation.fail_reason = '';
+          }
+
+          if (_.isFinite(observation.percent_completed) && observation.percent_completed > 0) {
+            observation.percent_completed = '<br/>percent completed: ' + observation.percent_completed.toFixed(1);
+          } else {
+            observation.percent_completed = '';
+          }
+          if (
+            observation.start !== previousObservation.start ||
+            observation.site !== previousObservation.site ||
+            observation.state !== previousObservation.state ||
+            observation.enclosure !== previousObservation.enclosure ||
+            observation.telescope !== previousObservation.telescope
+          ) {
+            let className = 'timeline_observation ' + previousObservation.state;
+            visGroups.add({ id: index, content: previousObservationIndex });
+            visData.add({
+              id: index,
+              group: index,
+              observationId: previousObservation.id,
+              title:
+                'telescope: ' +
+                previousObservation.site +
+                '.' +
+                previousObservation.enclosure +
+                '.' +
+                previousObservation.telescope +
+                previousObservation.percent_completed +
+                previousObservation.fail_reason +
+                '<br/>start: ' +
+                previousObservation.start.replace('T', ' ') +
+                '<br/>end: ' +
+                previousObservation.end.replace('T', ' '),
+              className: className,
+              start: previousObservation.start,
+              end: previousObservation.end,
+              toggle: 'tooltip',
+              html: true,
+              type: 'range'
+            });
+            index++;
+            previousObservationIndex = i + 1;
+          }
+          previousObservation = observation;
+        }
+        visGroups.add({ id: index, content: previousObservationIndex });
+        visData.add({
+          id: index,
+          group: index,
+          observationId: previousObservation.id,
+          title:
+            'telescope: ' +
+            previousObservation.site +
+            '.' +
+            previousObservation.enclosure +
+            '.' +
+            previousObservation.telescope +
+            previousObservation.percent_completed +
+            previousObservation.fail_reason +
+            '<br/>start: ' +
+            previousObservation.start.replace('T', ' ') +
+            '<br/>end: ' +
+            previousObservation.end.replace('T', ' '),
+          className: 'timeline_observation ' + previousObservation.state,
+          start: previousObservation.start,
+          end: previousObservation.end,
+          toggle: 'tooltip',
+          html: true,
+          type: 'range'
+        });
+        index++;
+        timeline_min = new Date(visData.get(index - 1)['start']);
+        timeline_max = new Date(visData.get(index - 1)['end']);
+        if (index > 12) {
+          for (let k = index - 1; k >= index - 12; k--) {
+            let start = new Date(visData.get(k)['start']);
+            let end = new Date(visData.get(k)['end']);
+            if (start < timeline_min) {
+              timeline_min = start;
+            }
+            if (end > timeline_max) {
+              timeline_max = end;
+            }
+          }
+          timeline_max.setMinutes(timeline_max.getMinutes() + 30);
+          timeline_min.setMinutes(timeline_min.getMinutes() - 30);
+        }
+      }
+      return { datasets: visData, groups: visGroups, window: { start: timeline_min, end: timeline_max } };
+    }
+  },
+  watch: {
+    data: function() {
+      let datasets = this.toVis;
+      //Need to first zero out the items and groups or vis.js throws an error
+      this.plot.setItems(new vis.DataSet());
+      this.plot.setGroups(new vis.DataSet());
+      this.plot.setGroups(datasets.groups);
+      this.plot.setItems(datasets.datasets);
+      this.plot.setWindow(datasets.window.start, datasets.window.end);
+    }
+  },
+  mounted: function() {
+    this.plot = this.buildPlot();
+    let that = this;
+    this.plot.on('click', function(event) {
+      if (event.item !== null) {
+        // An observation on the timeline was cliked, get that observation info
+        let item = that.toVis.datasets.get(event.item);
+        if (item !== null) {
+          that.$router.push({ name: 'observationDetail', params: { id: item.observationId } });
+        }
+      }
+    });
+  },
+  methods: {
+    buildPlot: function() {
+      // Set a unique name for the plot element, since vis.js needs this to separate plots
+      this.$refs.plot.setAttribute('class', _.uniqueId(this.$refs.plot.className));
+      return new vis.Timeline(this.$refs.plot, new vis.DataSet([]), this.options);
+    }
+  }
+};
+</script>
+<style>
+.SCHEDULED {
+  background-color: #c8dac2;
+  border-color: #658e57;
+}
+
+.NOT_ATTEMPTED {
+  background-color: olive;
+  border-color: darkolivegreen;
+}
+
+.CANCELED {
+  background-color: grey;
+  border-color: darkgrey;
+}
+
+.IN_PROGRESS {
+  background-color: lightgreen;
+  border-color: green;
+}
+
+.COMPLETED {
+  color: white;
+  background-color: green;
+  border-color: darkgreen;
+}
+
+.PARTIALLY-COMPLETED {
+  background-color: yellow;
+  border-color: goldenrod;
+}
+
+.FAILED {
+  background-color: red;
+  border-color: maroon;
+}
+
+.ABORTED {
+  background-color: orange;
+  border-color: darkorange;
+}
+</style>

--- a/src/components/Plots/ObservationHistoryPlot.vue
+++ b/src/components/Plots/ObservationHistoryPlot.vue
@@ -224,13 +224,12 @@ export default {
   },
   mounted: function() {
     this.plot = this.buildPlot();
-    let that = this;
-    this.plot.on('click', function(event) {
+    this.plot.on('click', event => {
       if (event.item !== null) {
         // An observation on the timeline was cliked, get that observation info
-        let item = that.toVis.datasets.get(event.item);
+        let item = this.toVis.datasets.get(event.item);
         if (item !== null) {
-          that.$emit('observationClicked', item.observationId);
+          this.$emit('observationClicked', item.observationId);
         }
       }
     });

--- a/src/components/Plots/ObservationHistoryPlot.vue
+++ b/src/components/Plots/ObservationHistoryPlot.vue
@@ -57,8 +57,8 @@ export default {
   },
   mixins: [plotZoomMixin],
   props: {
-    // TODO: Describe data, including that the observation state colors can be overridden by applying classes that are the
-    // state
+    // Observation data in the form returned from the `/api/requests/{requestId}/observations/` endpoint of the observation portal.
+    // Observation states are applied as CSS classes to each observation in the plot, these can be used to customize styling.
     data: {
       type: Array,
       required: true
@@ -230,7 +230,7 @@ export default {
         // An observation on the timeline was cliked, get that observation info
         let item = that.toVis.datasets.get(event.item);
         if (item !== null) {
-          that.$router.push({ name: 'observationDetail', params: { id: item.observationId } });
+          that.$emit('observationClicked', item.observationId);
         }
       }
     });

--- a/src/components/Plots/TelescopeStatesPlot.vue
+++ b/src/components/Plots/TelescopeStatesPlot.vue
@@ -97,6 +97,7 @@ export default {
     showZoomControls: {
       type: Boolean
     },
+    // Array of objects with mapping from eventType to event type description to be displayed in the legend.
     legendData: {
       type: Array,
       default: () => {
@@ -205,7 +206,7 @@ export default {
   watch: {
     data: function() {
       let datasets = this.toVis;
-      //Need to first zero out the items and groups or vis.js throws an error
+      // Need to first zero out the items and groups or vis.js throws an error
       this.plot.setItems(new vis.DataSet());
       this.plot.setGroups(new vis.DataSet());
       this.plot.setGroups(datasets.groups);
@@ -222,8 +223,8 @@ export default {
       let plot = new vis.Timeline(this.$refs.plot, new vis.DataSet([]), this.options);
       let that = this;
       plot.on('rangechanged', function() {
-        // on rangechanged, the user of this component can call the .updateWindow() method provided by
-        // the plotZoomMixin mixin.
+        // On rangechanged, the user of this component can call the .updateWindow() method on the
+        // component that is provided by the plotZoomMixin mixin.
         that.$emit('rangechanged', that.plot.getWindow());
       });
       return plot;

--- a/src/components/Plots/TelescopeStatesPlot.vue
+++ b/src/components/Plots/TelescopeStatesPlot.vue
@@ -183,6 +183,8 @@ export default {
       let plot = new vis.Timeline(this.$refs.plot, new vis.DataSet([]), this.options);
       let that = this;
       plot.on('rangechanged', function() {
+        // on rangechanged, the user of this component can call the .updateWindow() method provided by
+        // the plotZoomMixin mixin.
         that.$emit('rangechanged', that.plot.getWindow());
       });
       return plot;

--- a/src/components/Plots/TelescopeStatesPlot.vue
+++ b/src/components/Plots/TelescopeStatesPlot.vue
@@ -1,0 +1,192 @@
+<template>
+  <div>
+    <div ref="plot" class="telescopeStatesPlot">
+      <vis-plot-control v-show="showZoomControls" @plotZoom="plotZoom" />
+    </div>
+    <div v-if="showLegend && legendData.length > 0" class="telescopeStatesPlotLegend text-center">
+      <ul class="list-inline mt-1">
+        <li v-for="legendItem in legendData" :key="legendItem.eventType" class="list-inline-item">
+          <span class="legend-item align-middle mb-1 mr-1" :class="legendItem.eventType" />
+          {{ legendItem.text }}
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+<script>
+import vis from 'vis';
+import 'vis/dist/vis.css';
+import _ from 'lodash';
+
+import '@/assets/css/visPlot.css';
+import VisPlotControl from './VisPlotControl.vue';
+import { plotZoomMixin } from './visPlotMixins.js';
+
+export default {
+  name: 'TelescopeStatesPlot',
+  components: {
+    VisPlotControl
+  },
+  mixins: [plotZoomMixin],
+  props: {
+    // TODO: Add description of data, including that the event type code will be applied as a class to each telescope class
+    // on the plot as well as used in the legend, so add css classes defining background color and color
+    data: {
+      validator: function(value) {
+        return value === undefined || typeof value === 'object';
+      },
+      default: function() {
+        return undefined;
+      }
+    },
+    // Mapping of 3-letter site code to CSS color
+    siteCodeToColor: {
+      type: Object,
+      required: true
+    },
+    // Mapping of 3-letter site code to display name
+    siteCodeToName: {
+      type: Object,
+      required: true
+    },
+    activeObservation: {
+      type: Object,
+      default: function() {
+        return null;
+      }
+    },
+    showZoomControls: {
+      type: Boolean
+    },
+    legendData: {
+      type: Array,
+      default: () => {
+        return [];
+      }
+    },
+    showLegend: {
+      type: Boolean
+    }
+  },
+  data: function() {
+    let options = {
+      groupOrder: 'id',
+      stack: false,
+      maxHeight: '450px',
+      minHeight: '120px',
+      align: 'left',
+      dataAttributes: ['toggle', 'html'],
+      selectable: false,
+      zoomKey: 'ctrlKey',
+      moment: function(date) {
+        return vis.moment(date).utc();
+      },
+      tooltip: {
+        overflowMethod: 'cap'
+      }
+    };
+    return {
+      options: options
+    };
+  },
+  computed: {
+    toVis: function() {
+      let plotSites = new vis.DataSet();
+      let visData = new vis.DataSet();
+
+      if (this.data !== undefined) {
+        let sorted_telescopes = Object.keys(this.data).sort(function keyOrder(k1, k2) {
+          let s1 = k1.split('.')[2];
+          let s2 = k2.split('.')[2];
+
+          if (s1 < s2) return -1;
+          else if (s1 > s2) return +1;
+          else if (k1 < k2) return -1;
+          else if (k1 > k2) return +1;
+          else return 0;
+        });
+
+        let g = 0;
+        let used_telescopes = {};
+        for (let telescope in sorted_telescopes) {
+          let site = sorted_telescopes[telescope].split('.')[0];
+          if (!(site in used_telescopes)) {
+            used_telescopes[site] = 0;
+          }
+          used_telescopes[site]++;
+          plotSites.add({
+            id: g,
+            content: this.siteCodeToName[site] + ' ' + used_telescopes[site],
+            title: sorted_telescopes[telescope],
+            style: 'color: ' + this.siteCodeToColor[sorted_telescopes[telescope].split('.')[0]] + ';' + 'width: 130px;'
+          });
+          for (let index in this.data[sorted_telescopes[telescope]]) {
+            let event = this.data[sorted_telescopes[telescope]][index];
+            visData.add({
+              group: g,
+              title: event['event_reason'] + '<br/>start: ' + event['start'].replace('T', ' ') + '<br/>end: ' + event['end'].replace('T', ' '),
+              className: event['event_type'],
+              start: event['start'],
+              end: event['end'],
+              toggle: 'tooltip',
+              html: true,
+              type: 'range'
+            });
+          }
+          if (
+            this.activeObservation !== null &&
+            this.activeObservation.site === site &&
+            this.activeObservation.enclosure === sorted_telescopes[telescope].split('.')[1] &&
+            this.activeObservation.telescope === sorted_telescopes[telescope].split('.')[2]
+          ) {
+            visData.add({
+              group: g,
+              title:
+                this.activeObservation.state.toLowerCase() +
+                ' at ' +
+                sorted_telescopes[telescope] +
+                '<br/>start: ' +
+                this.activeObservation.start +
+                '<br/>end: ' +
+                this.activeObservation.end,
+              className: this.activeObservation.state,
+              start: this.activeObservation.start,
+              end: this.activeObservation.end,
+              toggle: 'tooltip',
+              html: true,
+              type: 'range'
+            });
+          }
+          g++;
+        }
+      }
+      return { datasets: visData, groups: plotSites };
+    }
+  },
+  watch: {
+    data: function() {
+      let datasets = this.toVis;
+      //Need to first zero out the items and groups or vis.js throws an error
+      this.plot.setItems(new vis.DataSet());
+      this.plot.setGroups(new vis.DataSet());
+      this.plot.setGroups(datasets.groups);
+      this.plot.setItems(datasets.datasets);
+    }
+  },
+  mounted: function() {
+    this.plot = this.buildPlot();
+  },
+  methods: {
+    buildPlot: function() {
+      // Set a unique name for the plot element, since vis.js needs this to separate plots
+      this.$refs.plot.setAttribute('class', _.uniqueId(this.$refs.plot.className));
+      let plot = new vis.Timeline(this.$refs.plot, new vis.DataSet([]), this.options);
+      let that = this;
+      plot.on('rangechanged', function() {
+        that.$emit('rangechanged', that.plot.getWindow());
+      });
+      return plot;
+    }
+  }
+};
+</script>

--- a/src/components/Plots/TelescopeStatesPlot.vue
+++ b/src/components/Plots/TelescopeStatesPlot.vue
@@ -29,8 +29,47 @@ export default {
   },
   mixins: [plotZoomMixin],
   props: {
-    // TODO: Add description of data, including that the event type code will be applied as a class to each telescope class
-    // on the plot as well as used in the legend, so add css classes defining background color and color
+    // Telescope states data. Given telescope states at telescopes `abc.domx.1m0a` and `def.domx.2m0a` where
+    // the first item is the site code, the second is the enclosure code, and the third is the telescope code,
+    // the data is structured as such:
+    //
+    // {
+    //   "abc.domx.1m0a": [
+    //     {
+    //       "telescope": "abc.domx.1m0a",
+    //       "event_type": "AVAILABLE",
+    //       "event_reason": "Available for scheduling",
+    //       "start": "2021-02-10T03:08:21.512615Z",
+    //       "end": "2021-02-10T03:12:42.221100Z"
+    //     },
+    //     {
+    //       "telescope": "abc.domx.1m0a",
+    //       "event_type": "AVAILABLE",
+    //       "event_reason": "Available for scheduling",
+    //       "start": "2021-02-11T03:04:25.780467Z",
+    //       "end": "2021-02-11T03:13:46.530521Z"
+    //     }
+    //   ],
+    //   "def.domx.2m0a": [
+    //     {
+    //       "telescope": "def.domx.2m0a",
+    //       "event_type": "AVAILABLE",
+    //       "event_reason": "Available for scheduling",
+    //       "start": "2021-02-01T02:51:28.304584Z",
+    //       "end": "2021-02-01T03:28:38.828000Z"
+    //     },
+    //     {
+    //       "telescope": "def.domx.2m0a",
+    //       "event_type": "NOT_OK_TO_OPEN",
+    //       "event_reason": "Weather: Raining",
+    //       "start": "2021-02-01T03:28:38.828000Z",
+    //       "end": "2021-02-01T03:28:40.059000Z"
+    //     }
+    //   ]
+    // }
+    //
+    // The event type code of the event will be applied as a class to each event on the plot. CSS rules setting the
+    // `background-color` and `border-color` can be added to visually differentiate the states on the plot.
     data: {
       validator: function(value) {
         return value === undefined || typeof value === 'object';

--- a/src/components/Plots/VisPlotControl.vue
+++ b/src/components/Plots/VisPlotControl.vue
@@ -1,0 +1,41 @@
+<template>
+  <b-container class="plot-control">
+    <b-button id="zoom-in" class="float-right" variant="transparent" @click="zoomIn">
+      <i class="fas fa-search-plus" />
+    </b-button>
+    <b-button id="zoom-in" class="float-right" variant="transparent" @click="zoomOut">
+      <i class="fas fa-search-minus" />
+    </b-button>
+  </b-container>
+</template>
+<script>
+export default {
+  name: 'VisPlotControl',
+  props: {
+    zoomInPercent: {
+      type: Number,
+      default: -0.2
+    },
+    zoomOutPercent: {
+      type: Number,
+      default: 0.2
+    }
+  },
+  methods: {
+    zoomIn: function() {
+      this.$emit('plotZoom', this.zoomInPercent);
+    },
+    zoomOut: function() {
+      this.$emit('plotZoom', this.zoomOutPercent);
+    }
+  }
+};
+</script>
+<style scoped>
+.plot-control {
+  position: absolute;
+  right: 0;
+  /* Stays under modals but above its vis graph */
+  z-index: 500;
+}
+</style>

--- a/src/components/Plots/index.js
+++ b/src/components/Plots/index.js
@@ -1,0 +1,5 @@
+import ObservationHistoryPlot from './ObservationHistoryPlot.vue';
+import TelescopeStatesPlot from './TelescopeStatesPlot.vue';
+import AirmassPlot from './AirmassPlot.vue';
+
+export { AirmassPlot, ObservationHistoryPlot, TelescopeStatesPlot };

--- a/src/components/Plots/visPlotMixins.js
+++ b/src/components/Plots/visPlotMixins.js
@@ -1,0 +1,18 @@
+export var plotZoomMixin = {
+  methods: {
+    plotZoom: function(zoomValue) {
+      var range = this.plot.getWindow();
+      var interval = range.end - range.start;
+      this.plot.setWindow({
+        start: range.start.valueOf() - interval * zoomValue,
+        end: range.end.valueOf() + interval * zoomValue
+      });
+    },
+    updateWindow: function(window) {
+      var currentWindow = this.plot.getWindow();
+      if (currentWindow.start !== window.start || currentWindow.end !== window.end) {
+        this.plot.setWindow(window.start, window.end, { animation: false });
+      }
+    }
+  }
+};

--- a/src/components/RequestGroups/RequestGroupHeader.vue
+++ b/src/components/RequestGroups/RequestGroupHeader.vue
@@ -17,15 +17,7 @@
     <b-col lg="auto" cols="12" class="p-1 flex-lg-fill">
       <div class="font-weight-bold">Proposal</div>
       <div>
-        <b-link v-if="proposalLink.href" :href="proposalLink.href" class="proposal-display-code">
-          {{ requestgroup.proposal }}
-        </b-link>
-        <b-link v-if="proposalLink.to" :to="proposalLink.to" class="proposal-display-code">
-          {{ requestgroup.proposal }}
-        </b-link>
-        <span v-else class="proposal-display-code">
-          {{ requestgroup.proposal }}
-        </span>
+        <text-display :link="proposalLink" :text="requestgroup.proposal" text-classes="proposal-display-code" />
       </div>
     </b-col>
     <b-col lg="auto" cols="12" class="p-1 flex-lg-fill">
@@ -49,9 +41,13 @@
 import _ from 'lodash';
 
 import { formatFloat, stateToBsClass, stateToIcon, formatDate } from '@/util';
+import { TextDisplay } from '@/components/Util';
 
 export default {
   name: 'RequestGroupHeader',
+  components: {
+    TextDisplay
+  },
   filters: {
     stateToBsClass: function(state, prefix) {
       return stateToBsClass(state, prefix);

--- a/src/components/RequestGroups/RequestGroupHeader.vue
+++ b/src/components/RequestGroups/RequestGroupHeader.vue
@@ -17,13 +17,13 @@
     <b-col lg="auto" cols="12" class="p-1 flex-lg-fill">
       <div class="font-weight-bold">Proposal</div>
       <div>
-        <b-link v-if="proposalLink.href" :href="proposalLink.href">
+        <b-link v-if="proposalLink.href" :href="proposalLink.href" class="proposal-display-code">
           {{ requestgroup.proposal }}
         </b-link>
-        <b-link v-if="proposalLink.to" :to="proposalLink.to">
+        <b-link v-if="proposalLink.to" :to="proposalLink.to" class="proposal-display-code">
           {{ requestgroup.proposal }}
         </b-link>
-        <span v-else>
+        <span v-else class="proposal-display-code">
           {{ requestgroup.proposal }}
         </span>
       </div>

--- a/src/components/RequestGroups/RequestGroupHeader.vue
+++ b/src/components/RequestGroups/RequestGroupHeader.vue
@@ -1,0 +1,97 @@
+<template>
+  <div class="d-flex flex-wrap">
+    <b-col lg="auto" cols="12" class="p-1 flex-lg-fill">
+      <div class="font-weight-bold">State</div>
+      <div :class="requestgroup.state | stateToBsClass('text')" class="text-truncate" :title="requestgroup.state">
+        <i :class="requestgroup.state | stateToIcon" />{{ requestgroup.state }}
+      </div>
+    </b-col>
+    <b-col lg="auto" cols="12" class="p-1 flex-lg-fill">
+      <div class="font-weight-bold">Updated</div>
+      <div>{{ requestgroup.modified | formatDate }}</div>
+    </b-col>
+    <b-col lg="auto" cols="12" class="p-1 flex-lg-fill">
+      <div class="font-weight-bold">Submitted</div>
+      <div>{{ requestgroup.created | formatDate }}</div>
+    </b-col>
+    <b-col lg="auto" cols="12" class="p-1 flex-lg-fill">
+      <div class="font-weight-bold">Proposal</div>
+      <div>
+        <b-link v-if="proposalLink.href" :href="proposalLink.href">
+          {{ requestgroup.proposal }}
+        </b-link>
+        <b-link v-if="proposalLink.to" :to="proposalLink.to">
+          {{ requestgroup.proposal }}
+        </b-link>
+        <span v-else>
+          {{ requestgroup.proposal }}
+        </span>
+      </div>
+    </b-col>
+    <b-col lg="auto" cols="12" class="p-1 flex-lg-fill">
+      <div class="font-weight-bold text-truncate">Submitter</div>
+      <div>{{ requestgroup.submitter }}</div>
+    </b-col>
+    <b-col lg="auto" cols="12" class="p-1 flex-lg-fill">
+      <div class="font-weight-bold">IPP</div>
+      <div>{{ requestgroup.ipp_value | formatIpp }}</div>
+    </b-col>
+    <b-col lg="auto" cols="12" class="p-1 flex-lg-fill">
+      <div class="font-weight-bold" title="Observation Type">Type</div>
+      <div>{{ requestgroup.observation_type }}</div>
+    </b-col>
+    <b-col v-if="showExtraColumn" lg="auto" cols="12" class="p-1 flex-lg-fill">
+      <slot name="extra-column-content"></slot>
+    </b-col>
+  </div>
+</template>
+<script>
+import _ from 'lodash';
+
+import { formatFloat, stateToBsClass, stateToIcon, formatDate } from '@/util';
+
+export default {
+  name: 'RequestGroupHeader',
+  filters: {
+    stateToBsClass: function(state, prefix) {
+      return stateToBsClass(state, prefix);
+    },
+    stateToIcon: function(state) {
+      return stateToIcon(state);
+    },
+    formatIpp: function(ipp) {
+      return formatFloat(ipp, 6);
+    },
+    formatDate: function(date) {
+      return formatDate(date);
+    }
+  },
+  props: {
+    requestgroup: {
+      type: Object,
+      required: true
+    },
+    // If true, an extra flex column is diplayed, showing the content in the "extra-column-content" named slot.
+    showExtraColumn: {
+      type: Boolean
+    },
+    // Set `proposalLink` to turn the displayed proposal ID into a link. Pass in an object with either { "href": "..." } specifying
+    // the "href" attribute for a normal <a> tag or { "to": ... } specifying a vue-router target route "to" attribute
+    // for the <router-link> tag.
+    proposalLink: {
+      type: Object,
+      required: false,
+      default: () => {
+        return {};
+      },
+      validator: value => {
+        let hasHref = 'href' in value;
+        let hasTo = 'to' in value;
+        if (hasHref && hasTo) return false;
+        if (_.isEmpty(value)) return true;
+        return hasHref || hasTo;
+      }
+    }
+  }
+};
+</script>

--- a/src/components/RequestGroups/RequestGroupHeader.vue
+++ b/src/components/RequestGroups/RequestGroupHeader.vue
@@ -40,7 +40,7 @@
       <div class="font-weight-bold" title="Observation Type">Type</div>
       <div>{{ requestgroup.observation_type }}</div>
     </b-col>
-    <b-col v-if="showExtraColumn" lg="auto" cols="12" class="p-1 flex-lg-fill">
+    <b-col v-if="showExtraColumn" lg="auto" cols="12" class="p-1 flex-lg-fill" v-bind="extraColumnAttrs" :class="extraColumnClasses">
       <slot name="extra-column-content"></slot>
     </b-col>
   </div>
@@ -74,6 +74,16 @@ export default {
     // If true, an extra flex column is diplayed, showing the content in the "extra-column-content" named slot.
     showExtraColumn: {
       type: Boolean
+    },
+    extraColumnAttrs: {
+      type: Object,
+      default: () => {
+        return {};
+      }
+    },
+    extraColumnClasses: {
+      type: String,
+      default: ''
     },
     // Set `proposalLink` to turn the displayed proposal ID into a link. Pass in an object with either { "href": "..." } specifying
     // the "href" attribute for a normal <a> tag or { "to": ... } specifying a vue-router target route "to" attribute

--- a/src/components/RequestGroups/RequestGroupHeader.vue
+++ b/src/components/RequestGroups/RequestGroupHeader.vue
@@ -38,8 +38,6 @@
   </div>
 </template>
 <script>
-import _ from 'lodash';
-
 import { formatFloat, stateToBsClass, stateToIcon, formatDate } from '@/util';
 import { TextDisplay } from '@/components/Util';
 
@@ -89,13 +87,6 @@ export default {
       required: false,
       default: () => {
         return {};
-      },
-      validator: value => {
-        let hasHref = 'href' in value;
-        let hasTo = 'to' in value;
-        if (hasHref && hasTo) return false;
-        if (_.isEmpty(value)) return true;
-        return hasHref || hasTo;
       }
     }
   }

--- a/src/components/RequestGroups/RequestGroupOverview.vue
+++ b/src/components/RequestGroups/RequestGroupOverview.vue
@@ -4,15 +4,7 @@
       <div class="state-color-marker" :class="requestgroup.state | stateToBsClass('bg')"></div>
       <b-col md="8" cols="12">
         <slot name="requestgroup-name">
-          <b-link v-if="requestgroupLink.href" :href="requestgroupLink.href" class="requestgroup-title">
-            {{ requestgroupDisplayName }}
-          </b-link>
-          <b-link v-if="requestgroupLink.to" :to="requestgroupLink.to" class="requestgroup-title">
-            {{ requestgroupDisplayName }}
-          </b-link>
-          <span v-else class="requestgroup-title">
-            {{ requestgroupDisplayName }}
-          </span>
+          <text-display :display-text="requestgroupDisplayName" :link="requestgroupLink" display-text-classes="requestgroup-title" />
         </slot>
         <b-row>
           <b-col class="pr-1 text-truncate">
@@ -20,15 +12,7 @@
               <div><i class="fa fa-fw fa-user" /> {{ requestgroup.submitter }}</div>
               <div>
                 <i class="fa fa-fw fa-users" />
-                <b-link v-if="proposalLink.href" :href="proposalLink.href" class="proposal-display-code">
-                  {{ requestgroup.proposal }}
-                </b-link>
-                <b-link v-if="proposalLink.to" :to="proposalLink.to" class="proposal-display-code">
-                  {{ requestgroup.proposal }}
-                </b-link>
-                <span v-else class="proposal-display-code">
-                  {{ requestgroup.proposal }}
-                </span>
+                <text-display :display-text="requestgroup.proposal" :link="proposalLink" display-text-classes="proposal-display-code" />
               </div>
             </div>
           </b-col>
@@ -61,12 +45,14 @@
   </b-col>
 </template>
 <script>
-import _ from 'lodash';
-
+import { TextDisplay } from '@/components/Util';
 import { stateToBsClass, stateToIcon, formatDate, timeFromNow } from '@/util';
 
 export default {
   name: 'RequestGroupOverview',
+  components: {
+    TextDisplay
+  },
   filters: {
     requestStateCount: function(requestgroup, states) {
       let count = 0;
@@ -103,13 +89,6 @@ export default {
       required: false,
       default: () => {
         return {};
-      },
-      validator: value => {
-        let hasHref = 'href' in value;
-        let hasTo = 'to' in value;
-        if (hasHref && hasTo) return false;
-        if (_.isEmpty(value)) return true;
-        return hasHref || hasTo;
       }
     },
     // Set `requestgroupLink` to turn the displayed requestgroup ID into a link. Pass in an object with either { "href": "..." } specifying
@@ -120,13 +99,6 @@ export default {
       required: false,
       default: function() {
         return {};
-      },
-      validator: value => {
-        let hasHref = 'href' in value;
-        let hasTo = 'to' in value;
-        if (hasHref && hasTo) return false;
-        if (_.isEmpty(value)) return true;
-        return hasHref || hasTo;
       }
     }
   },

--- a/src/components/RequestGroups/RequestGroupOverview.vue
+++ b/src/components/RequestGroups/RequestGroupOverview.vue
@@ -4,7 +4,7 @@
       <div class="state-color-marker" :class="requestgroup.state | stateToBsClass('bg')"></div>
       <b-col md="8" cols="12">
         <slot name="requestgroup-name">
-          <text-display :display-text="requestgroupDisplayName" :link="requestgroupLink" display-text-classes="requestgroup-title" />
+          <text-display :text="requestgroupDisplayName" :link="requestgroupLink" text-classes="requestgroup-title" />
         </slot>
         <b-row>
           <b-col class="pr-1 text-truncate">
@@ -12,7 +12,7 @@
               <div><i class="fa fa-fw fa-user" /> {{ requestgroup.submitter }}</div>
               <div>
                 <i class="fa fa-fw fa-users" />
-                <text-display :display-text="requestgroup.proposal" :link="proposalLink" display-text-classes="proposal-display-code" />
+                <text-display :text="requestgroup.proposal" :link="proposalLink" text-classes="proposal-display-code" />
               </div>
             </div>
           </b-col>

--- a/src/components/RequestGroups/index.js
+++ b/src/components/RequestGroups/index.js
@@ -1,4 +1,5 @@
+import RequestGroupHeader from './RequestGroupHeader.vue';
 import RequestGroupOverview from './RequestGroupOverview.vue';
 import RequestGroupTable from './RequestGroupTable.vue';
 
-export { RequestGroupOverview, RequestGroupTable };
+export { RequestGroupHeader, RequestGroupOverview, RequestGroupTable };

--- a/src/components/Requests/RequestOverview.vue
+++ b/src/components/Requests/RequestOverview.vue
@@ -69,6 +69,7 @@ export default {
       type: Object,
       required: true
     },
+    // If true, content in the "extra-column-content" named slot is displayed.
     showExtraColumn: {
       type: Boolean
     },

--- a/src/components/Requests/RequestOverview.vue
+++ b/src/components/Requests/RequestOverview.vue
@@ -1,0 +1,131 @@
+<template>
+  <b-row class="m-0 border position-relative">
+    <div class="state-color-marker" :class="request.state | stateToBsClass('bg')"></div>
+    <b-col>
+      <b-row>
+        <b-col cols="12" md class="request-block border-right">
+          <b-link v-if="requestLink.href" :href="requestLink.href" class="request-display-code request-title"> # {{ request.id }} </b-link>
+          <b-link v-if="requestLink.to" :to="requestLink.to" class="request-display-code request-title"> # {{ request.id }} </b-link>
+          <span v-else class="request-display-code request-title"> # {{ request.id }} </span>
+          <p>
+            <i class="far fa-clock" />
+            <span title="Total exposure time + observing overhead">Duration: {{ request.duration }} seconds</span>
+          </p>
+          <p>
+            <i class="fa fa-camera" />
+            Instrument: {{ instrumentName }}
+          </p>
+        </b-col>
+        <b-col cols="12" md class="request-block border-right">
+          <p>
+            <span :class="request.state | stateToBsClass('text')">
+              <i :class="request.state | stateToIcon" />
+              {{ request.state }}
+            </span>
+          </p>
+          <p>
+            <i class="fa fa-clipboard-check" />
+            Acceptability Threshold: {{ request.acceptability_threshold }}%
+          </p>
+          <p>
+            <i class="fa fa-calendar" />
+            {{ request.modified | formatDate }}
+          </p>
+        </b-col>
+        <b-col v-if="showExtraColumn" v-bind="extraColumnAttrs" :class="extraColumnClasses">
+          <slot name="extra-column-content"></slot>
+        </b-col>
+      </b-row>
+    </b-col>
+  </b-row>
+</template>
+<script>
+import _ from 'lodash';
+
+import { stateToBsClass, stateToIcon, formatDate } from '@/util';
+
+export default {
+  name: 'RequestOverview',
+  filters: {
+    stateToBsClass: function(state, prefix) {
+      return stateToBsClass(state, prefix);
+    },
+    stateToIcon: function(state) {
+      return stateToIcon(state);
+    },
+    formatDate(value) {
+      return formatDate(value);
+    }
+  },
+  props: {
+    request: {
+      type: Object,
+      required: true
+    },
+    // Response from the /api/instruments/ endpoint or a mapping like {"instrument_type": { "name": "Instrument display name" }, ... }
+    instruments: {
+      type: Object,
+      required: true
+    },
+    showExtraColumn: {
+      type: Boolean
+    },
+    extraColumnAttrs: {
+      type: Object,
+      default: () => {
+        return {};
+      }
+    },
+    extraColumnClasses: {
+      type: String,
+      default: ''
+    },
+    // Set `requestLink` to turn the displayed request ID into a link. Pass in an object with either { "href": "..." } specifying
+    // the "href" attribute for a normal <a> tag or { "to": ... } specifying a vue-router target route "to" attribute
+    // for the <router-link> tag.
+    requestLink: {
+      type: Object,
+      required: false,
+      default: () => {
+        return {};
+      },
+      validator: value => {
+        let hasHref = 'href' in value;
+        let hasTo = 'to' in value;
+        if (hasHref && hasTo) return false;
+        if (_.isEmpty(value)) return true;
+        return hasHref || hasTo;
+      }
+    }
+  },
+  computed: {
+    instrumentName: function() {
+      let instrumentType = _.get(this.request, ['configurations', 0, 'instrument_type']);
+      if (instrumentType && instrumentType in this.instruments) {
+        return this.instruments[instrumentType].name;
+      } else {
+        return instrumentType;
+      }
+    }
+  }
+};
+</script>
+<style scoped>
+.request-block > p {
+  margin: 0px;
+  padding-bottom: 0px;
+}
+.request-title {
+  font-size: 1em;
+  margin-left: 4px;
+  font-weight: 600;
+}
+.state-color-marker {
+  position: absolute;
+  top: 0;
+  left: 0;
+  max-width: 10px;
+  min-width: 10px;
+  height: 100%;
+}
+</style>

--- a/src/components/Requests/RequestOverview.vue
+++ b/src/components/Requests/RequestOverview.vue
@@ -4,9 +4,7 @@
     <b-col>
       <b-row>
         <b-col cols="12" md class="request-block border-right">
-          <b-link v-if="requestLink.href" :href="requestLink.href" class="request-display-code request-title"> # {{ request.id }} </b-link>
-          <b-link v-else-if="requestLink.to" :to="requestLink.to" class="request-display-code request-title"> # {{ request.id }} </b-link>
-          <span v-else class="request-display-code request-title"> # {{ request.id }} </span>
+          <text-display :link="requestLink" :text="'# ' + request.id" text-classes="request-display-code request-title" />
           <p>
             <i class="far fa-clock" />
             <span title="Total exposure time + observing overhead">Duration: {{ request.duration }} seconds</span>
@@ -42,6 +40,7 @@
 <script>
 import _ from 'lodash';
 
+import { TextDisplay } from '@/components/Util';
 import { stateToBsClass, stateToIcon, formatDate } from '@/util';
 
 export default {
@@ -56,6 +55,9 @@ export default {
     formatDate(value) {
       return formatDate(value);
     }
+  },
+  components: {
+    TextDisplay
   },
   props: {
     request: {
@@ -88,13 +90,6 @@ export default {
       required: false,
       default: () => {
         return {};
-      },
-      validator: value => {
-        let hasHref = 'href' in value;
-        let hasTo = 'to' in value;
-        if (hasHref && hasTo) return false;
-        if (_.isEmpty(value)) return true;
-        return hasHref || hasTo;
       }
     }
   },

--- a/src/components/Requests/RequestOverview.vue
+++ b/src/components/Requests/RequestOverview.vue
@@ -5,7 +5,7 @@
       <b-row>
         <b-col cols="12" md class="request-block border-right">
           <b-link v-if="requestLink.href" :href="requestLink.href" class="request-display-code request-title"> # {{ request.id }} </b-link>
-          <b-link v-if="requestLink.to" :to="requestLink.to" class="request-display-code request-title"> # {{ request.id }} </b-link>
+          <b-link v-else-if="requestLink.to" :to="requestLink.to" class="request-display-code request-title"> # {{ request.id }} </b-link>
           <span v-else class="request-display-code request-title"> # {{ request.id }} </span>
           <p>
             <i class="far fa-clock" />

--- a/src/components/Requests/RequestWindowsDetail.vue
+++ b/src/components/Requests/RequestWindowsDetail.vue
@@ -32,3 +32,8 @@ export default {
   }
 };
 </script>
+<style scoped>
+.no-top-border > tr > td {
+  border-top: none;
+}
+</style>

--- a/src/components/Requests/RequestWindowsDetail.vue
+++ b/src/components/Requests/RequestWindowsDetail.vue
@@ -1,0 +1,34 @@
+<template>
+  <table class="table table-sm">
+    <thead class="no-top-border">
+      <tr>
+        <td><strong>Start</strong></td>
+        <td><strong>End</strong></td>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="(window, index) in windows" :key="'window-' + index">
+        <td>{{ window.start | formatDate }}</td>
+        <td>{{ window.end | formatDate }}</td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+<script>
+import { formatDate } from '@/util';
+
+export default {
+  name: 'RequestWindowsDetail',
+  filters: {
+    formatDate: function(value) {
+      return formatDate(value);
+    }
+  },
+  props: {
+    windows: {
+      type: Array,
+      required: true
+    }
+  }
+};
+</script>

--- a/src/components/Requests/index.js
+++ b/src/components/Requests/index.js
@@ -1,3 +1,4 @@
 import RequestOverview from './RequestOverview.vue';
+import RequestWindowsDetail from './RequestWindowsDetail.vue';
 
-export { RequestOverview };
+export { RequestOverview, RequestWindowsDetail };

--- a/src/components/Requests/index.js
+++ b/src/components/Requests/index.js
@@ -1,0 +1,3 @@
+import RequestOverview from './RequestOverview.vue';
+
+export { RequestOverview };

--- a/src/components/Util/DataLoader.vue
+++ b/src/components/Util/DataLoader.vue
@@ -1,14 +1,18 @@
 <template>
   <b-container fluid class="p-0">
     <template v-if="dataLoadError">
-      <p class="text-center my-2">
-        {{ loadErrorMessage }}
-      </p>
+      <slot name="data-load-error">
+        <p class="text-center my-2">
+          {{ loadErrorMessage }}
+        </p>
+      </slot>
     </template>
     <template v-else-if="!dataLoaded">
-      <div class="text-center my-2">
-        <i class="fa fa-spin fa-spinner" />
-      </div>
+      <slot name="data-loading">
+        <div class="text-center my-2">
+          <i class="fa fa-spin fa-spinner" />
+        </div>
+      </slot>
     </template>
     <template v-else-if="dataLoaded && dataNotFound">
       <slot name="not-found">

--- a/src/components/Util/DataLoader.vue
+++ b/src/components/Util/DataLoader.vue
@@ -1,0 +1,49 @@
+<template>
+  <b-container fluid class="p-0">
+    <template v-if="dataLoadError">
+      <p class="text-center my-2">
+        {{ loadErrorMessage }}
+      </p>
+    </template>
+    <template v-else-if="!dataLoaded">
+      <div class="text-center my-2">
+        <i class="fa fa-spin fa-spinner" />
+      </div>
+    </template>
+    <template v-else-if="dataLoaded && dataNotFound">
+      <slot name="not-found">
+        {{ notFoundMessage }}
+      </slot>
+    </template>
+    <template v-else>
+      <slot> </slot>
+    </template>
+  </b-container>
+</template>
+<script>
+export default {
+  name: 'DataLoader',
+  props: {
+    dataLoaded: {
+      type: Boolean,
+      required: true
+    },
+    dataLoadError: {
+      type: Boolean,
+      required: true
+    },
+    dataNotFound: {
+      type: Boolean,
+      required: true
+    },
+    loadErrorMessage: {
+      type: String,
+      default: 'Oops, there was a problem getting your data. Please try again.'
+    },
+    notFoundMessage: {
+      type: String,
+      default: 'Not found.'
+    }
+  }
+};
+</script>

--- a/src/components/Util/TextDisplay.vue
+++ b/src/components/Util/TextDisplay.vue
@@ -1,0 +1,46 @@
+<template>
+  <b-link v-if="link.href" :href="link.href" :class="textClasses">
+    {{ text }}
+  </b-link>
+  <b-link v-else-if="link.to" :to="link.to" :class="textClasses">
+    {{ text }}
+  </b-link>
+  <span v-else :class="textClasses">
+    {{ text }}
+  </span>
+</template>
+<script>
+import _ from 'lodash';
+
+export default {
+  name: 'TextDisplay',
+  props: {
+    text: {
+      type: String,
+      required: true
+    },
+    textClasses: {
+      type: String,
+      required: false,
+      default: ''
+    },
+    // Set `link` to turn the displayed text into a link. Pass in an object with either { "href": "..." } specifying
+    // the "href" attribute for a normal <a> tag or { "to": ... } specifying a vue-router target route "to" attribute
+    // for the <router-link> tag.
+    link: {
+      type: Object,
+      required: false,
+      default: () => {
+        return {};
+      },
+      validator: value => {
+        let hasHref = 'href' in value;
+        let hasTo = 'to' in value;
+        if (hasHref && hasTo) return false;
+        if (_.isEmpty(value)) return true;
+        return hasHref || hasTo;
+      }
+    }
+  }
+};
+</script>

--- a/src/components/Util/index.js
+++ b/src/components/Util/index.js
@@ -1,3 +1,4 @@
 import Pagination from './Pagination.vue';
+import DataLoader from './DataLoader.vue';
 
-export { Pagination };
+export { DataLoader, Pagination };

--- a/src/components/Util/index.js
+++ b/src/components/Util/index.js
@@ -1,4 +1,5 @@
 import Pagination from './Pagination.vue';
 import DataLoader from './DataLoader.vue';
+import TextDisplay from './TextDisplay.vue';
 
-export { DataLoader, Pagination };
+export { DataLoader, TextDisplay, Pagination };

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,16 +1,22 @@
+// All the components exported from this file are available through the library
+
 import { RequestConfigurationsDetail } from './Configurations';
 import { RequestGroupHeader, RequestGroupOverview, RequestGroupTable } from './RequestGroups';
 import { ObservationDetail } from './Observations';
 import { RequestOverview, RequestWindowsDetail } from './Requests';
+import { AirmassPlot, ObservationHistoryPlot, TelescopeStatesPlot } from './Plots';
 import { Pagination } from './Util';
 
 export {
+  AirmassPlot,
   ObservationDetail,
+  ObservationHistoryPlot,
   Pagination,
   RequestConfigurationsDetail,
   RequestGroupHeader,
   RequestGroupOverview,
   RequestGroupTable,
   RequestOverview,
-  RequestWindowsDetail
+  RequestWindowsDetail,
+  TelescopeStatesPlot
 };

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -5,10 +5,11 @@ import { RequestGroupHeader, RequestGroupOverview, RequestGroupTable } from './R
 import { ObservationDetail } from './Observations';
 import { RequestOverview, RequestWindowsDetail } from './Requests';
 import { AirmassPlot, ObservationHistoryPlot, TelescopeStatesPlot } from './Plots';
-import { Pagination } from './Util';
+import { DataLoader, Pagination } from './Util';
 
 export {
   AirmassPlot,
+  DataLoader,
   ObservationDetail,
   ObservationHistoryPlot,
   Pagination,

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,5 +1,6 @@
 import { RequestConfigurationsDetail } from './Configurations';
 import { RequestGroupHeader, RequestGroupOverview, RequestGroupTable } from './RequestGroups';
+import { RequestOverview } from './Requests';
 import { Pagination } from './Util';
 
-export { RequestConfigurationsDetail, RequestGroupHeader, RequestGroupOverview, RequestGroupTable, Pagination };
+export { RequestConfigurationsDetail, RequestGroupHeader, RequestGroupOverview, RequestGroupTable, RequestOverview, Pagination };

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,5 +1,5 @@
 import { RequestConfigurationsDetail } from './Configurations';
-import { RequestGroupOverview, RequestGroupTable } from './RequestGroups';
+import { RequestGroupHeader, RequestGroupOverview, RequestGroupTable } from './RequestGroups';
 import { Pagination } from './Util';
 
-export { RequestConfigurationsDetail, RequestGroupOverview, RequestGroupTable, Pagination };
+export { RequestConfigurationsDetail, RequestGroupHeader, RequestGroupOverview, RequestGroupTable, Pagination };

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,6 +1,7 @@
 import { RequestConfigurationsDetail } from './Configurations';
 import { RequestGroupHeader, RequestGroupOverview, RequestGroupTable } from './RequestGroups';
+import { ObservationDetail } from './Observations';
 import { RequestOverview } from './Requests';
 import { Pagination } from './Util';
 
-export { RequestConfigurationsDetail, RequestGroupHeader, RequestGroupOverview, RequestGroupTable, RequestOverview, Pagination };
+export { ObservationDetail, Pagination, RequestConfigurationsDetail, RequestGroupHeader, RequestGroupOverview, RequestGroupTable, RequestOverview };

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,7 +1,16 @@
 import { RequestConfigurationsDetail } from './Configurations';
 import { RequestGroupHeader, RequestGroupOverview, RequestGroupTable } from './RequestGroups';
 import { ObservationDetail } from './Observations';
-import { RequestOverview } from './Requests';
+import { RequestOverview, RequestWindowsDetail } from './Requests';
 import { Pagination } from './Util';
 
-export { ObservationDetail, Pagination, RequestConfigurationsDetail, RequestGroupHeader, RequestGroupOverview, RequestGroupTable, RequestOverview };
+export {
+  ObservationDetail,
+  Pagination,
+  RequestConfigurationsDetail,
+  RequestGroupHeader,
+  RequestGroupOverview,
+  RequestGroupTable,
+  RequestOverview,
+  RequestWindowsDetail
+};

--- a/src/mixins/getDataMixins.js
+++ b/src/mixins/getDataMixins.js
@@ -2,8 +2,8 @@ import $ from 'jquery';
 
 export var getDataMixin = {
   /*
-  Mixin to retrieve a single object from the observation portal API given an endpoint to query.
-  You must override the `initializeDataEndpoint()` function. This mixin works well with the DataLoader
+  Mixin to retrieve a single response from the observation portal API given an endpoint to query.
+  The `initializeDataEndpoint()` function must be overridden. This mixin works well with the DataLoader
   component.
   */
   data: function() {
@@ -15,11 +15,6 @@ export var getDataMixin = {
       data: this.initializeEmptyData(),
       dataEndpoint: dataEndpoint
     };
-  },
-  computed: {
-    observationPortalApiUrl: function() {
-      return this.$store.state.urls.observationPortalApi;
-    }
   },
   created: function() {
     this.getData();
@@ -39,7 +34,7 @@ export var getDataMixin = {
       this.clearLoadStates();
       let that = this;
       $.ajax({
-        url: this.observationPortalApiUrl + this.dataEndpoint
+        url: this.dataEndpoint
       })
         .done(function(response) {
           that.successCallback(response);
@@ -62,6 +57,7 @@ export var getDataMixin = {
       } else {
         this.dataLoadError = true;
       }
+      this.onDataRetrievalError(response);
     },
     successCallback: function(response) {
       this.data = response;
@@ -69,6 +65,10 @@ export var getDataMixin = {
     },
     onSuccessfulRetrieval: function(response) {
       // Override this function to run an action when data retrieval is successful.
+      return response;
+    },
+    onDataRetrievalError: function(response) {
+      // Override this function to run an action when data retrieval errors.
       return response;
     }
   }

--- a/src/mixins/getDataMixins.js
+++ b/src/mixins/getDataMixins.js
@@ -1,0 +1,132 @@
+import $ from 'jquery';
+
+export var getDataMixin = {
+  /*
+  Mixin to retrieve a single object from the observation portal API given an endpoint to query.
+  You must override the `initializeDataEndpoint()` function. This mixin works well with the DataLoader
+  component.
+  */
+  data: function() {
+    const dataEndpoint = this.initializeDataEndpoint();
+    return {
+      dataLoadError: false,
+      dataLoaded: false,
+      dataNotFound: false,
+      data: this.initializeEmptyData(),
+      dataEndpoint: dataEndpoint
+    };
+  },
+  computed: {
+    observationPortalApiUrl: function() {
+      return this.$store.state.urls.observationPortalApi;
+    }
+  },
+  created: function() {
+    this.getData();
+  },
+  methods: {
+    initializeDataEndpoint: function() {
+      // Override this method to initialize the endpoint from which data will be retrieved.
+      return '';
+    },
+    setDataEndpoint: function(newEndpoint) {
+      this.dataEndpoint = newEndpoint;
+    },
+    initializeEmptyData: function() {
+      return {};
+    },
+    getData: function() {
+      this.clearLoadStates();
+      let that = this;
+      $.ajax({
+        url: this.observationPortalApiUrl + this.dataEndpoint
+      })
+        .done(function(response) {
+          that.successCallback(response);
+        })
+        .fail(function(response) {
+          that.failCallback(response);
+        })
+        .always(function() {
+          that.dataLoaded = true;
+        });
+    },
+    clearLoadStates: function() {
+      this.dataLoaded = false;
+      this.dataLoadError = false;
+      this.dataNotFound = false;
+    },
+    failCallback: function(response) {
+      if (response.status === 404 || response.status === 403) {
+        this.dataNotFound = true;
+      } else {
+        this.dataLoadError = true;
+      }
+    },
+    successCallback: function(response) {
+      this.data = response;
+      this.onSuccessfulRetrieval(response);
+    },
+    onSuccessfulRetrieval: function(response) {
+      // Override this function to run an action when data retrieval is successful.
+      return response;
+    }
+  }
+};
+
+export var getDataListMixin = {
+  /*
+  Extends `getDataMixin`.
+
+  Mixin to retrieve a list of objects from the observation portal API given an endpoint to query.
+  You must override the `initializeDataEndpoint()` function.
+  */
+  mixins: [getDataMixin],
+  data: function() {
+    return {
+      setNotFoundOnEmptyList: this.initializeSetNotFoundOnEmptyList()
+    };
+  },
+  methods: {
+    initializeEmptyData: function() {
+      return [];
+    },
+    initializeSetNotFoundOnEmptyList: function() {
+      // Override this to return true if the desired behavior is to set that data is not found
+      // when an empty list is returned.
+      return false;
+    },
+    successCallback(response) {
+      if (response.length < 1 && this.setNotFoundOnEmptyList) {
+        this.dataNotFound = true;
+      } else {
+        this.onSuccessfulRetrieval(response);
+        this.data = response;
+      }
+    }
+  }
+};
+
+export var getDataListWithCountMixin = {
+  /*
+  Extends `getDataListMixin`.
+
+  Mixin to retrieve an object containing a list of results as well as a count of how many results
+  there are in total from the observation portal API given an endpoint to query. You must override
+  the `initializeDataEndpoint()` function.
+  */
+  mixins: [getDataListMixin],
+  methods: {
+    initializeEmptyData: function() {
+      return { count: 0, results: [] };
+    },
+    successCallback(response) {
+      if (response.results.length < 1 && this.setNotFoundOnEmptyList) {
+        this.dataNotFound = true;
+      } else {
+        this.onSuccessfulRetrieval(response);
+        this.data = response;
+      }
+    }
+  }
+};

--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -1,3 +1,4 @@
 import { paginationAndFilteringMixin } from './paginationMixins.js';
+import { getDataMixin, getDataListMixin, getDataListWithCountMixin } from './getDataMixins.js';
 
-export { paginationAndFilteringMixin };
+export { getDataMixin, getDataListMixin, getDataListWithCountMixin, paginationAndFilteringMixin };

--- a/src/util.js
+++ b/src/util.js
@@ -83,6 +83,18 @@ function formatDate(date, formatString) {
   }
 }
 
+function formatFloat(value, precision) {
+  /* Round a number and format it with the given precision */
+  let valueAsNumber = Number(value);
+  precision = precision || 0;
+  if (valueAsNumber === 0 || valueAsNumber) {
+    const multiplier = Math.pow(10, precision);
+    return (Math.round(valueAsNumber * multiplier) / multiplier).toFixed(precision);
+  } else {
+    return value;
+  }
+}
+
 function stateToBsClass(state, classPrefix) {
   let state_map = {
     PENDING: 'info',
@@ -126,8 +138,9 @@ export {
   decimalDecToSexigesimal,
   decimalRaToSexigesimal,
   formatDate,
-  formatValue,
   formatField,
+  formatFloat,
+  formatValue,
   stateToBsClass,
   stateToIcon,
   timeFromNow

--- a/tests/unit/ObservationDetail.spec.js
+++ b/tests/unit/ObservationDetail.spec.js
@@ -1,0 +1,111 @@
+import { createLocalVue, enableAutoDestroy, mount } from '@vue/test-utils';
+import BootstrapVue from 'bootstrap-vue';
+
+import ObservationDetail from '@/components/Observations/ObservationDetail.vue';
+
+// Make sure the bootstrap-vue components are available during testing
+const localVue = createLocalVue();
+localVue.use(BootstrapVue);
+
+// Call the .destroy() hook on the test Vue instance after each test
+enableAutoDestroy(afterEach);
+
+const observationFactory = () => {
+  return {
+    site: 'tst',
+    enclosure: 'abcd',
+    telescope: '1m0a',
+    start: '2021-01-28T10:49:59Z',
+    end: '2021-01-28T10:55:21Z',
+    priority: 10,
+    configuration_statuses: [
+      {
+        id: 263311141,
+        summary: {
+          start: '2021-01-28T10:50:19Z',
+          end: '2021-01-28T10:52:58Z',
+          state: 'COMPLETED',
+          reason: '',
+          time_completed: 120.0,
+          events: [
+            {
+              time: '2021-01-28T10:52:57',
+              state: 'PROCESSING',
+              description: 'TakeExposure'
+            },
+            {
+              time: '2021-01-28T10:52:57',
+              state: 'DONE',
+              description: 'TakeExposure'
+            }
+          ]
+        },
+        instrument_name: 'in01',
+        guide_camera_name: 'in02',
+        state: 'COMPLETED',
+        configuration: 12345678
+      }
+    ],
+    request: 87654321,
+    state: 'COMPLETED',
+    modified: '2021-01-28T10:52:58.565167Z',
+    created: '2021-01-28T10:47:34.886207Z'
+  };
+};
+
+const wrapperFactory = (observation = {}, requestLink = {}) => {
+  return mount(ObservationDetail, {
+    localVue,
+    propsData: {
+      observation: observation,
+      requestLink: requestLink
+    }
+  });
+};
+
+describe('ObservationDetail.vue', () => {
+  it('displays observation details', () => {
+    let observationData = observationFactory();
+    const wrapper = wrapperFactory(observationData);
+    expect(wrapper.text()).toContain(observationData.state);
+    expect(wrapper.text()).toContain(observationData.site);
+    expect(wrapper.text()).toContain(observationData.enclosure);
+    expect(wrapper.text()).toContain(observationData.telescope);
+  });
+
+  it('displays request ID without link', () => {
+    let observationData = observationFactory();
+    const wrapper = wrapperFactory(observationData);
+    expect(wrapper.find('.request-display-code').text()).toContain(observationData.request);
+    expect(
+      wrapper
+        .find('.request-display-code')
+        .find('a')
+        .exists()
+    ).toBe(false);
+  });
+
+  it('displays request ID as link using href', () => {
+    let observationData = observationFactory();
+    const wrapper = wrapperFactory(observationData, { href: 'http://localhost' });
+    expect(wrapper.find('.request-display-code').text()).toContain(observationData.request);
+    expect(
+      wrapper
+        .find('.request-display-code')
+        .find('a')
+        .exists()
+    ).toBe(true);
+  });
+
+  it('displays request ID as link using to', () => {
+    let observationData = observationFactory();
+    const wrapper = wrapperFactory(observationData, { to: { name: 'observationDetail' } });
+    expect(wrapper.find('.request-display-code').text()).toContain(observationData.request);
+    expect(
+      wrapper
+        .find('.request-display-code')
+        .find('a')
+        .exists()
+    ).toBe(true);
+  });
+});

--- a/tests/unit/RequestGroupHeader.spec.js
+++ b/tests/unit/RequestGroupHeader.spec.js
@@ -1,0 +1,166 @@
+import { createLocalVue, enableAutoDestroy, mount } from '@vue/test-utils';
+import BootstrapVue from 'bootstrap-vue';
+
+import RequestGroupHeader from '@/components/RequestGroups/RequestGroupHeader.vue';
+
+// Make sure the bootstrap-vue components are available during testing
+const localVue = createLocalVue();
+localVue.use(BootstrapVue);
+
+// Call the .destroy() hook on the test Vue instance after each test
+enableAutoDestroy(afterEach);
+
+const requestFactory = (state = 'PENDING') => {
+  return {
+    acceptability_threshold: 90,
+    state: state,
+    configurations: [
+      {
+        type: 'EXPOSE',
+        instrument_type: 'instrument_a',
+        instrument_configs: [
+          {
+            bin_x: 1,
+            bin_y: 1,
+            exposure_count: 1,
+            exposure_time: '60',
+            mode: 'default',
+            rotator_mode: '',
+            extra_params: {
+              defocus: 0
+            },
+            optical_elements: {
+              filter: 'r'
+            }
+          }
+        ],
+        acquisition_config: {
+          mode: 'OFF',
+          extra_params: {}
+        },
+        guiding_config: {
+          mode: 'ON',
+          optional: true,
+          extra_params: {}
+        },
+        target: {
+          name: 'm88',
+          type: 'ICRS',
+          ra: 187.996733,
+          dec: 14.420411,
+          epoch: 2000
+        },
+        constraints: {
+          max_airmass: 2,
+          min_lunar_distance: 30
+        }
+      }
+    ],
+    windows: [
+      {
+        start: '2021-02-24 23:37:04',
+        end: '2021-02-25 23:37:04'
+      }
+    ],
+    location: {
+      telescope_class: '1m0'
+    }
+  };
+};
+
+const requestgroupFactory = (requestStates = ['PENDING']) => {
+  let requestgroupData = {
+    name: 'test requestgroup',
+    proposal: 'test proposal',
+    submitter: 'test user',
+    ipp_value: 1.05,
+    operator: 'SINGLE',
+    observation_type: 'NORMAL',
+    duration: 925,
+    observation_note: '',
+    state: 'PENDING',
+    modified: '2021-02-03T04:55:30.000055',
+    created: '2021-02-03T04:55:28.474845Z',
+    requests: []
+  };
+  for (let requestState of requestStates) {
+    requestgroupData.requests.push(requestFactory(requestState));
+  }
+  return requestgroupData;
+};
+
+const wrapperFactory = (requestgroup = {}, proposalLink = {}, showExtraColumn = false, slots = {}) => {
+  return mount(RequestGroupHeader, {
+    localVue,
+    propsData: {
+      requestgroup: requestgroup,
+      proposalLink: proposalLink,
+      showExtraColumn: showExtraColumn
+    },
+    slots: slots
+  });
+};
+
+describe('RequestGroupHeader.vue', () => {
+  it('displays requestgroup details', () => {
+    let requestgroupData = requestgroupFactory();
+    let displaySubmittedTime = '2021-02-03 04:55:28';
+    let displayUpdatedTime = '2021-02-03 04:55:30';
+    let displayIpp = '1.050000';
+    const wrapper = wrapperFactory(requestgroupData);
+    expect(wrapper.text()).toContain(requestgroupData.state);
+    expect(wrapper.text()).toContain(requestgroupData.proposal);
+    expect(wrapper.text()).toContain(displayUpdatedTime);
+    expect(wrapper.text()).toContain(displaySubmittedTime);
+    expect(wrapper.text()).toContain(requestgroupData.submitter);
+    expect(wrapper.text()).toContain(displayIpp);
+  });
+
+  it('displays proposal without link', () => {
+    let requestgroupData = requestgroupFactory();
+    const wrapper = wrapperFactory(requestgroupData);
+    expect(wrapper.find('.proposal-display-code').text()).toContain(requestgroupData.proposal);
+    expect(
+      wrapper
+        .find('.proposal-display-code')
+        .find('a')
+        .exists()
+    ).toBe(false);
+  });
+
+  it('displays proposal as link using href', () => {
+    let requestgroupData = requestgroupFactory();
+    const wrapper = wrapperFactory(requestgroupData, { href: 'http://localhost' });
+    expect(wrapper.find('.proposal-display-code').text()).toContain(requestgroupData.proposal);
+    expect(
+      wrapper
+        .find('.proposal-display-code')
+        .find('a')
+        .exists()
+    ).toBe(true);
+  });
+
+  it('displays proposal as link using to', () => {
+    let requestgroupData = requestgroupFactory();
+    const wrapper = wrapperFactory(requestgroupData, { to: { name: 'proposalPath', params: { id: 1 } } });
+    expect(wrapper.find('.proposal-display-code').text()).toContain(requestgroupData.proposal);
+    expect(
+      wrapper
+        .find('.proposal-display-code')
+        .find('a')
+        .exists()
+    ).toBe(true);
+  });
+
+  it('does not display extra column slot if setting to display it is false', () => {
+    let requestgroupData = requestgroupFactory();
+    const wrapper = wrapperFactory(requestgroupData, {}, false, { 'extra-column-content': '<span>Some extra content</span>' });
+    expect(wrapper.text()).not.toContain('Some extra content');
+  });
+
+  it('displays extra column slot', () => {
+    let requestgroupData = requestgroupFactory();
+    const wrapper = wrapperFactory(requestgroupData, {}, true, { 'extra-column-content': '<span>Some extra content</span>' });
+    expect(wrapper.text()).toContain('Some extra content');
+  });
+});

--- a/tests/unit/RequestOverview.spec.js
+++ b/tests/unit/RequestOverview.spec.js
@@ -1,0 +1,140 @@
+import { createLocalVue, enableAutoDestroy, mount } from '@vue/test-utils';
+import BootstrapVue from 'bootstrap-vue';
+
+import RequestOverview from '@/components/Requests/RequestOverview.vue';
+
+// Make sure the bootstrap-vue components are available during testing
+const localVue = createLocalVue();
+localVue.use(BootstrapVue);
+
+// Call the .destroy() hook on the test Vue instance after each test
+enableAutoDestroy(afterEach);
+
+const requestFactory = (state = 'PENDING') => {
+  return {
+    id: 12345,
+    acceptability_threshold: 90,
+    duration: 137,
+    state: state,
+    configurations: [
+      {
+        type: 'EXPOSE',
+        instrument_type: 'instrument_a',
+        instrument_configs: [
+          {
+            bin_x: 1,
+            bin_y: 1,
+            exposure_count: 1,
+            exposure_time: '60',
+            mode: 'default',
+            rotator_mode: '',
+            extra_params: {
+              defocus: 0
+            },
+            optical_elements: {
+              filter: 'r'
+            }
+          }
+        ],
+        acquisition_config: {
+          mode: 'OFF',
+          extra_params: {}
+        },
+        guiding_config: {
+          mode: 'ON',
+          optional: true,
+          extra_params: {}
+        },
+        target: {
+          name: 'm88',
+          type: 'ICRS',
+          ra: 187.996733,
+          dec: 14.420411,
+          epoch: 2000
+        },
+        constraints: {
+          max_airmass: 2,
+          min_lunar_distance: 30
+        }
+      }
+    ],
+    windows: [
+      {
+        start: '2021-02-24 23:37:04',
+        end: '2021-02-25 23:37:04'
+      }
+    ],
+    location: {
+      telescope_class: '1m0'
+    }
+  };
+};
+
+const instrumentsFactory = (instrumentCode) => {
+  return { instrumentCode: { name: 'Instrument Code' } };
+}
+
+const wrapperFactory = (request = {}, instruments = {}, requestLink = {}, slots = {}, showExtraColumn = false) => {
+  return mount(RequestOverview, {
+    localVue,
+    propsData: {
+      request: request,
+      instruments: instruments,
+      requestLink: requestLink,
+      showExtraColumn: showExtraColumn
+    },
+    slots: slots
+  });
+};
+
+describe('RequestOverview.vue', () => {
+  it('displays request details', () => {
+    let requestData = requestFactory();
+    const wrapper = wrapperFactory(requestData, instrumentsFactory());
+    expect(wrapper.text()).toContain(requestData.id);
+    expect(wrapper.text()).toContain(requestData.duration);
+    expect(wrapper.text()).toContain(requestData.state);
+  });
+
+  it('displays request ID without link', () => {
+    let requestData = requestFactory();
+    const wrapper = wrapperFactory(requestData, instrumentsFactory());
+    expect(wrapper.find('.request-title').text()).toContain(requestData.id);
+    expect(
+      wrapper
+        .find('.request-title')
+        .find('a')
+        .exists()
+    ).toBe(false);
+  });
+
+  it('displays request ID as link using href', () => {
+    let requestData = requestFactory();
+    const wrapper = wrapperFactory(requestData, instrumentsFactory(), { href: 'http://localhost' });
+    expect(wrapper.find('.request-title').text()).toContain(requestData.id);
+    expect(
+      wrapper
+        .find('.request-title')
+        .find('a')
+        .exists()
+    ).toBe(true);
+  });
+
+  it('displays request ID as link using to', () => {
+    let requestData = requestFactory();
+    const wrapper = wrapperFactory(requestData, instrumentsFactory(), { to: { name: 'rgPath', params: { id: 1 } } });
+    expect(wrapper.find('.request-title').text()).toContain(requestData.id);
+    expect(
+      wrapper
+        .find('.request-title')
+        .find('a')
+        .exists()
+    ).toBe(true);
+  });
+
+  it('displays extra column slot content', () => {
+    let requestData = requestFactory();
+    const wrapper = wrapperFactory(requestData, instrumentsFactory(), {}, { 'extra-column-content': '<span>I go in extra column</span>' }, true);
+    expect(wrapper.text()).toContain('I go in extra column');
+  });
+});

--- a/tests/unit/RequestOverview.spec.js
+++ b/tests/unit/RequestOverview.spec.js
@@ -70,9 +70,11 @@ const requestFactory = (state = 'PENDING') => {
   };
 };
 
-const instrumentsFactory = (instrumentCode) => {
-  return { instrumentCode: { name: 'Instrument Code' } };
-}
+const instrumentsFactory = (instrumentCode = 'instrument_a') => {
+  let instruments = {};
+  instruments[instrumentCode] = { name: 'Instrument Code' };
+  return instruments;
+};
 
 const wrapperFactory = (request = {}, instruments = {}, requestLink = {}, slots = {}, showExtraColumn = false) => {
   return mount(RequestOverview, {

--- a/tests/unit/RequestWindowsDetail.spec.js
+++ b/tests/unit/RequestWindowsDetail.spec.js
@@ -15,15 +15,19 @@ enableAutoDestroy(afterEach);
 const windowFactory = (nWindows = 1) => {
   let windows = [];
   for (let i = 0; i < nWindows; i++) {
-    windows.push(
-      {
-        start: moment.utc('2021-02-02', 'YYYY-MM-DD').add(i, 'days').format(),
-        end: moment.utc('2021-02-02', 'YYYY-MM-DD').add(i + 1, 'days').format()
-      }
-    );
+    windows.push({
+      start: moment
+        .utc('2021-02-02', 'YYYY-MM-DD')
+        .add(i, 'days')
+        .format(),
+      end: moment
+        .utc('2021-02-02', 'YYYY-MM-DD')
+        .add(i + 1, 'days')
+        .format()
+    });
   }
   return windows;
-}
+};
 
 const wrapperFactory = (windows = {}) => {
   return mount(RequestWindowsDetail, {

--- a/tests/unit/RequestWindowsDetail.spec.js
+++ b/tests/unit/RequestWindowsDetail.spec.js
@@ -1,0 +1,53 @@
+import { createLocalVue, enableAutoDestroy, mount } from '@vue/test-utils';
+import BootstrapVue from 'bootstrap-vue';
+import moment from 'moment';
+
+import { formatDate } from '@/util';
+import RequestWindowsDetail from '@/components/Requests/RequestWindowsDetail.vue';
+
+// Make sure the bootstrap-vue components are available during testing
+const localVue = createLocalVue();
+localVue.use(BootstrapVue);
+
+// Call the .destroy() hook on the test Vue instance after each test
+enableAutoDestroy(afterEach);
+
+const windowFactory = (nWindows = 1) => {
+  let windows = [];
+  for (let i = 0; i < nWindows; i++) {
+    windows.push(
+      {
+        start: moment.utc('2021-02-02', 'YYYY-MM-DD').add(i, 'days').format(),
+        end: moment.utc('2021-02-02', 'YYYY-MM-DD').add(i + 1, 'days').format()
+      }
+    );
+  }
+  return windows;
+}
+
+const wrapperFactory = (windows = {}) => {
+  return mount(RequestWindowsDetail, {
+    localVue,
+    propsData: {
+      windows: windows
+    }
+  });
+};
+
+describe('RequestWindowsDetail.vue', () => {
+  it('displays window details of single window', () => {
+    let windowData = windowFactory();
+    const wrapper = wrapperFactory(windowData);
+    expect(wrapper.text()).toContain(formatDate(windowData[0].start));
+    expect(wrapper.text()).toContain(formatDate(windowData[0].end));
+  });
+
+  it('displays window details of multiple windows', () => {
+    let windowData = windowFactory(2);
+    const wrapper = wrapperFactory(windowData);
+    expect(wrapper.text()).toContain(formatDate(windowData[0].start));
+    expect(wrapper.text()).toContain(formatDate(windowData[0].end));
+    expect(wrapper.text()).toContain(formatDate(windowData[1].start));
+    expect(wrapper.text()).toContain(formatDate(windowData[1].end));
+  });
+});

--- a/tests/unit/util.spec.js
+++ b/tests/unit/util.spec.js
@@ -3,6 +3,7 @@ import {
   decimalDecToSexigesimal,
   formatValue,
   formatField,
+  formatFloat,
   formatDate,
   stateToBsClass,
   stateToIcon,
@@ -78,4 +79,42 @@ describe('timeFromNow', () => {
     let result = timeFromNow('2009-10-10 00:00:00'); // This date is definitely in the past
     expect(result).toContain('ago');
   });
+});
+
+describe('formatFloat', () => {
+  it('formats float to precision 0 rounding up', () => {
+    let value = 41.666;
+    let result = formatFloat(value);
+    let expected = '42';
+    expect(result).toEqual(expected);
+  });
+
+  it('formats float represented as string to precision 0 rounding up', () => {
+    let value = '41.666';
+    let result = formatFloat(value);
+    let expected = '42';
+    expect(result).toEqual(expected);
+  });
+
+  it('formats float represented as string to precision 0', () => {
+    let value = '41.166';
+    let result = formatFloat(value);
+    let expected = '41';
+    expect(result).toEqual(expected);
+  });
+
+  it('formats float to precision 5', () => {
+    let value = 41.12;
+    let result = formatFloat(value, 5);
+    let expected = '41.12000';
+    expect(result).toEqual(expected);
+  });
+
+  it('formats zero', () => {
+    let value = '0';
+    let result = formatFloat(value, 1);
+    let expected = '0.0';
+    expect(result).toEqual(expected);
+  });
+
 });

--- a/tests/unit/util.spec.js
+++ b/tests/unit/util.spec.js
@@ -116,5 +116,4 @@ describe('formatFloat', () => {
     let expected = '0.0';
     expect(result).toEqual(expected);
   });
-
 });

--- a/vue.config.js
+++ b/vue.config.js
@@ -21,6 +21,18 @@ module.exports = {
           commonjs2: 'moment',
           amd: 'moment',
           root: 'moment'
+        },
+        vis: {
+          commonjs: 'vis',
+          commonjs2: 'vis',
+          amd: 'vis',
+          root: 'vis'
+        },
+        'vis/dist/vis.css': {
+          commonjs: 'vis/dist/vis.css',
+          commonjs2: 'vis/dist/vis.css',
+          amd: 'vis/dist/vis.css',
+          root: 'vis/dist/vis.css'
         }
       });
     }


### PR DESCRIPTION
Added components for the request, requestgroup, and observation detail views, providing slots and props for custom content. These include the following:
- High level detail component for requests, with a slot to add an extra column with custom content - `RequestOverview`
- Another high level component displaying key pieces of requestgroup information, with a slot to add an extra column for custom content - `RequestGroupHeader`
- A component to display details for a request's windows - `RequestWindowsDetail`
- A component displaying observation details - `ObservationDetail`
- A plot to display airmass vs. time - `AirmassPlot`
- A plot to display telescope states vs. time - `TelescopeStatesPlot`
- A plot to display a history of scheduled observations - `ObservationHistoryPlot`

Also added the `DataLoader` component and `getDataMixin`, `getDataListMixin`, and `getDataListWithCountMixin`. The data loader component can be used together with these mixins. The mixins handle getting data from a specified endpoint and set variables for different loading states, which can then be used together with the data loader component to display either an error message, a loading indicator, or the downloaded content. No other component in the lib actually uses these mixins or the data loader component, these just seemed like useful things for the library to provide.