### PR TITLE
Feature/additional requestgroups filters

### DIFF
--- a/src/components/RequestGroups/RequestGroupTable.vue
+++ b/src/components/RequestGroups/RequestGroupTable.vue
@@ -222,10 +222,9 @@ export default {
       return options;
     },
     semesterOptions: function() {
-      let semesterOptions = [{value: '', text: '---------'}];
-      for (let semesterId of Object.keys(this.semesterData))
-      {
-        semesterOptions.push( {value: semesterId, text: semesterId } );
+      let semesterOptions = [{ value: '', text: '---------' }];
+      for (let semesterId of Object.keys(this.semesterData)) {
+        semesterOptions.push({ value: semesterId, text: semesterId });
       }
       return semesterOptions;
     },

--- a/src/components/RequestGroups/RequestGroupTable.vue
+++ b/src/components/RequestGroups/RequestGroupTable.vue
@@ -37,6 +37,7 @@
                 <template v-slot:label> <i class="fa fa-calendar-check" /> Semester </template>
                 <b-form-select id="input-semester" v-model="semesterSelection" :options="semesterOptions" size="sm" @change="onSemesterChange" />
               </b-form-group>
+              <!-- TODO: Make created_after and created_before datetime fields so that users can specify start/end dates and times. -->
               <b-form-group id="input-group-created-after" label-for="input-created-after" label-class="m-0" class="my-2">
                 <b-form-input id="input-created-after" v-model="createdAfterSelection" type="date" size="sm" />
                 <template v-slot:label>
@@ -237,6 +238,7 @@ export default {
       },
       set(createdAfterDate) {
         let createdAfterDateTime = moment.utc(createdAfterDate, 'YYYY-MM-DD');
+        // set the created_after time to 00:00:00 - the beginning of the day
         createdAfterDateTime.set({ hour: 0, minute: 0, second: 0 });
         this.queryParams.created_after = formatDate(createdAfterDateTime.format(), 'YYYY-MM-DD HH:mm:ss');
       }
@@ -247,6 +249,7 @@ export default {
       },
       set(createdBeforeDate) {
         let createdBeforeDateTime = moment.utc(createdBeforeDate, 'YYYY-MM-DD');
+        // set the created_before time to 23:59:59 so that the query is inclusive for the entire day specified
         createdBeforeDateTime.set({ hour: 23, minute: 59, second: 59 });
         this.queryParams.created_before = formatDate(createdBeforeDateTime.format(), 'YYYY-MM-DD HH:mm:ss');
       }

--- a/src/components/RequestGroups/RequestGroupTable.vue
+++ b/src/components/RequestGroups/RequestGroupTable.vue
@@ -34,8 +34,8 @@
                 <b-form-select id="input-proposal" v-model="queryParams.proposal" :options="proposalOptions" size="sm" />
               </b-form-group>
               <b-form-group id="input-group-semester" label-for="input-semester" label-class="m-0" class="my-2">
-                <template v-slot:label> <i class="fa fa-users" /> Semester </template>
-                <b-form-select id="input-semester" :options="semesterOptions" size="sm" @change="onSemesterChange" />
+                <template v-slot:label> <i class="fa fa-calendar-check" /> Semester </template>
+                <b-form-select id="input-semester" v-model="semesterSelect" :options="semesterOptions" size="sm" @change="onSemesterChange" />
               </b-form-group>
               <b-form-group id="input-group-created-after" label-for="input-created-after" label-class="m-0" class="my-2">
                 <b-form-input id="input-created-after" v-model="queryParams.created_after" type="date" size="sm" />
@@ -193,11 +193,15 @@ export default {
       { value: 'end', text: 'End of window' },
       { value: '-end', text: 'End of window (descending)' }
     ];
-    const semesterOptions = [{ value: { id: '', start: '', end: '' }, text: '-----------' }];
+    const semesterData = { '': { start: '', end: '', id: '' } };
+    const semesterOptions = [{ value: '', text: '---------', selected: true }];
+    const semesterSelect = '';
     return {
       orderOptions: orderOptions,
       stateOptions: stateOptions,
+      semesterData: semesterData,
       semesterOptions: semesterOptions,
+      semesterSelect: semesterSelect,
       fields: [{ key: 'requestgroupInfo', tdClass: 'p-0 m-0', thClass: 'border-0' }]
     };
   },
@@ -248,12 +252,14 @@ export default {
     },
     updateSemesterOptions: function(data) {
       for (let semester of data.results) {
-        this.semesterOptions.push({ value: semester, text: semester.id });
+        this.semesterData[semester.id] = semester;
+        this.semesterOptions.push({ value: semester.id, text: semester.id });
       }
     },
-    onSemesterChange: function(e) {
-      this.queryParams.created_after = formatDate(e.start, 'YYYY-MM-DD');
-      this.queryParams.created_before = formatDate(e.end, 'YYYY-MM-DD');
+    onSemesterChange: function(event) {
+      let selectedSemesterData = this.semesterData[event];
+      this.queryParams.created_after = formatDate(selectedSemesterData.start, 'YYYY-MM-DD');
+      this.queryParams.created_before = formatDate(selectedSemesterData.end, 'YYYY-MM-DD');
     },
     onSuccessfulDataRetrieval: function(response) {
       this.$emit('success', response);
@@ -262,7 +268,6 @@ export default {
       this.$emit('error', response);
     },
     getSemesterOptions: function() {
-      // function to get past semesters
       let that = this;
       let datetimeNow = formatDate(moment.utc().format());
       $.ajax({

--- a/src/components/RequestGroups/RequestGroupTable.vue
+++ b/src/components/RequestGroups/RequestGroupTable.vue
@@ -193,14 +193,12 @@ export default {
       { value: 'end', text: 'End of window' },
       { value: '-end', text: 'End of window (descending)' }
     ];
-    const semesterData = { '': { start: '', end: '', id: '' } };
-    const semesterOptions = [{ value: '', text: '---------', selected: true }];
+    const semesterData = {};
     const semesterSelect = '';
     return {
       orderOptions: orderOptions,
       stateOptions: stateOptions,
       semesterData: semesterData,
-      semesterOptions: semesterOptions,
       semesterSelect: semesterSelect,
       fields: [{ key: 'requestgroupInfo', tdClass: 'p-0 m-0', thClass: 'border-0' }]
     };
@@ -222,6 +220,14 @@ export default {
         }
       }
       return options;
+    },
+    semesterOptions: function() {
+      let semesterOptions = [{value: '', text: '---------'}];
+      for (let semesterId of Object.keys(this.semesterData))
+      {
+        semesterOptions.push( {value: semesterId, text: semesterId } );
+      }
+      return semesterOptions;
     },
     viewAuthoredRequestsOnly: function() {
       return this.profile.profile && this.profile.profile.view_authored_requests_only && !this.profile.profile.staff_view;
@@ -250,16 +256,15 @@ export default {
       };
       return defaultQueryParams;
     },
-    updateSemesterOptions: function(data) {
+    updateSemesterData: function(data) {
       for (let semester of data.results) {
-        this.semesterData[semester.id] = semester;
-        this.semesterOptions.push({ value: semester.id, text: semester.id });
+        this.$set(this.semesterData, semester.id, semester);
       }
     },
-    onSemesterChange: function(event) {
-      let selectedSemesterData = this.semesterData[event];
-      this.queryParams.created_after = formatDate(selectedSemesterData.start, 'YYYY-MM-DD');
-      this.queryParams.created_before = formatDate(selectedSemesterData.end, 'YYYY-MM-DD');
+    onSemesterChange: function(semesterId) {
+      let selectedSemesterData = this.semesterData[semesterId];
+      this.queryParams.created_after = formatDate(_.get(selectedSemesterData, 'start', ''), 'YYYY-MM-DD');
+      this.queryParams.created_before = formatDate(_.get(selectedSemesterData, 'end', ''), 'YYYY-MM-DD');
     },
     onSuccessfulDataRetrieval: function(response) {
       this.$emit('success', response);
@@ -274,7 +279,7 @@ export default {
         url: this.observationPortalApiBaseUrl + '/api/semesters/?limit=20&start_lte=' + datetimeNow,
         type: 'GET'
       }).done(function(data) {
-        that.updateSemesterOptions(data);
+        that.updateSemesterData(data);
       });
     }
   }

--- a/tests/unit/RequestGroupTable.spec.js
+++ b/tests/unit/RequestGroupTable.spec.js
@@ -296,12 +296,11 @@ describe('RequestGroupTable.vue', () => {
     await createdAfterForm.setValue('2021-02-01');
 
     expect(wrapper.vm.semesterSelection).toBe('');
-    
+
     // Simulate updating both to valid semester boundaries
     await createdAfterForm.setValue('2021-02-01');
     await createdBeforeForm.setValue('2021-07-31');
 
     expect(wrapper.vm.semesterSelection).toBe('2021A');
-
   });
 });

--- a/tests/unit/RequestGroupTable.spec.js
+++ b/tests/unit/RequestGroupTable.spec.js
@@ -2,7 +2,7 @@ import { createLocalVue, enableAutoDestroy, mount } from '@vue/test-utils';
 import BootstrapVue from 'bootstrap-vue';
 import flushPromises from 'flush-promises';
 import VueRouter from 'vue-router';
-import $ from 'jquery';
+import $, { ajax } from 'jquery';
 
 import { RequestGroupTable, RequestGroupOverview } from '@/components/RequestGroups';
 import { Pagination } from '@/components/Util';
@@ -243,10 +243,15 @@ describe('RequestGroupTable.vue', () => {
   });
 
   it('filters requestgroups by state', async () => {
+    let semesterResults = {
+      count: 1,
+      results: [{id: '2021A', start: '2021-02-01T00:00:00Z', end: '2021-07-31T23:59:59Z'}],
+                          };
     let requestgroupListDataUnfiltered = requestgroupListFactory(['PENDING', 'COMPLETED', 'PENDING']);
     let requestgroupListDataFiltered = requestgroupListFactory(['COMPLETED']);
     $.ajax
       .mockReturnValueOnce(Deferred().resolve(requestgroupListDataUnfiltered))
+      .mockReturnValueOnce(Deferred().resolve(semesterResults))
       .mockReturnValueOnce(Deferred().resolve(requestgroupListDataFiltered));
 
     const wrapper = wrapperFactory('http://localhost', profileData);
@@ -254,24 +259,34 @@ describe('RequestGroupTable.vue', () => {
     // with the expected parameters.
     expect(wrapper.findAllComponents(RequestGroupOverview)).toHaveLength(3);
     expect(wrapper.vm.$route.fullPath).toBe('/?limit=20');
-    expect($.ajax.mock.calls.length).toBe(1);
+    expect($.ajax.mock.calls.length).toBe(2);
     expect($.ajax.mock.calls[0][0].data.limit).toBe(20);
     expect($.ajax.mock.calls[0][0].data.state).toBeFalsy();
 
-    // Simulate updating the filter choice for requestgroup state
+    // Simulate updating the filter choice for requestgroup state and semester
     let filterButton = wrapper.find('button[type=submit]');
     let stateSelect = wrapper.find('select#input-state');
-    await stateSelect.setValue('COMPLETED');
+    let semesterSelect = wrapper.find('select#input-semester');
+    await stateSelect.setValue(['COMPLETED']);
+
+    //wrapper.setValue does not seem to work, so get the first valid semester option and select it manually
+    semesterSelect.element.options[1].selected = true;
+    await semesterSelect.trigger('change');
     filterButton.trigger('submit');
     await flushPromises();
 
     // Check that the second AJAX call used the right query params and also that
     // only one requestgroup is displayed now
-    expect($.ajax.mock.calls.length).toBe(2);
-    expect($.ajax.mock.calls[1][0].data.limit).toBe(20);
-    expect($.ajax.mock.calls[1][0].data.state).toBe('COMPLETED');
+    expect($.ajax.mock.calls.length).toBe(3);
+    expect($.ajax.mock.calls[2][0].data.limit).toBe(20);
+    expect($.ajax.mock.calls[2][0].data.state).toStrictEqual(["COMPLETED"]);
     expect(wrapper.vm.$route.fullPath).toContain('state=COMPLETED');
     expect(wrapper.vm.$route.fullPath).toContain('limit=20');
+    expect(wrapper.vm.$route.fullPath).toContain('created_after=2021-02-01');
+    expect(wrapper.vm.$route.fullPath).toContain('created_before=2021-07-31');
     expect(wrapper.findAllComponents(RequestGroupOverview)).toHaveLength(1);
+    expect(wrapper.vm.queryParams.created_after).toBe('2021-02-01');
+    expect(wrapper.vm.queryParams.created_before).toBe('2021-07-31');
+
   });
 });

--- a/tests/unit/RequestGroupTable.spec.js
+++ b/tests/unit/RequestGroupTable.spec.js
@@ -2,7 +2,7 @@ import { createLocalVue, enableAutoDestroy, mount } from '@vue/test-utils';
 import BootstrapVue from 'bootstrap-vue';
 import flushPromises from 'flush-promises';
 import VueRouter from 'vue-router';
-import $, { ajax } from 'jquery';
+import $ from 'jquery';
 
 import { RequestGroupTable, RequestGroupOverview } from '@/components/RequestGroups';
 import { Pagination } from '@/components/Util';
@@ -245,8 +245,8 @@ describe('RequestGroupTable.vue', () => {
   it('filters requestgroups by state', async () => {
     let semesterResults = {
       count: 1,
-      results: [{id: '2021A', start: '2021-02-01T00:00:00Z', end: '2021-07-31T23:59:59Z'}],
-                          };
+      results: [{ id: '2021A', start: '2021-02-01T00:00:00Z', end: '2021-07-31T23:59:59Z' }]
+    };
     let requestgroupListDataUnfiltered = requestgroupListFactory(['PENDING', 'COMPLETED', 'PENDING']);
     let requestgroupListDataFiltered = requestgroupListFactory(['COMPLETED']);
     $.ajax
@@ -279,7 +279,7 @@ describe('RequestGroupTable.vue', () => {
     // only one requestgroup is displayed now
     expect($.ajax.mock.calls.length).toBe(3);
     expect($.ajax.mock.calls[2][0].data.limit).toBe(20);
-    expect($.ajax.mock.calls[2][0].data.state).toStrictEqual(["COMPLETED"]);
+    expect($.ajax.mock.calls[2][0].data.state).toStrictEqual(['COMPLETED']);
     expect(wrapper.vm.$route.fullPath).toContain('state=COMPLETED');
     expect(wrapper.vm.$route.fullPath).toContain('limit=20');
     expect(wrapper.vm.$route.fullPath).toContain('created_after=2021-02-01');
@@ -287,6 +287,5 @@ describe('RequestGroupTable.vue', () => {
     expect(wrapper.findAllComponents(RequestGroupOverview)).toHaveLength(1);
     expect(wrapper.vm.queryParams.created_after).toBe('2021-02-01');
     expect(wrapper.vm.queryParams.created_before).toBe('2021-07-31');
-
   });
 });

--- a/tests/unit/RequestGroupTable.spec.js
+++ b/tests/unit/RequestGroupTable.spec.js
@@ -285,7 +285,5 @@ describe('RequestGroupTable.vue', () => {
     expect(wrapper.vm.$route.fullPath).toContain('created_after=2021-02-01');
     expect(wrapper.vm.$route.fullPath).toContain('created_before=2021-07-31');
     expect(wrapper.findAllComponents(RequestGroupOverview)).toHaveLength(1);
-    expect(wrapper.vm.queryParams.created_after).toBe('2021-02-01');
-    expect(wrapper.vm.queryParams.created_before).toBe('2021-07-31');
   });
 });

--- a/tests/unit/RequestGroupTable.spec.js
+++ b/tests/unit/RequestGroupTable.spec.js
@@ -268,10 +268,7 @@ describe('RequestGroupTable.vue', () => {
     let stateSelect = wrapper.find('select#input-state');
     let semesterSelect = wrapper.find('select#input-semester');
     await stateSelect.setValue(['COMPLETED']);
-
-    //wrapper.setValue does not seem to work, so get the first valid semester option and select it manually
-    semesterSelect.element.options[1].selected = true;
-    await semesterSelect.trigger('change');
+    await semesterSelect.setValue('2021A');
     filterButton.trigger('submit');
     await flushPromises();
 

--- a/tests/unit/RequestGroupTable.spec.js
+++ b/tests/unit/RequestGroupTable.spec.js
@@ -282,5 +282,26 @@ describe('RequestGroupTable.vue', () => {
     expect(wrapper.vm.$route.fullPath).toContain('created_after=2021-02-01');
     expect(wrapper.vm.$route.fullPath).toContain('created_before=2021-07-31');
     expect(wrapper.findAllComponents(RequestGroupOverview)).toHaveLength(1);
+
+    // Simulate updating the submitted_after date to test semester check
+    let createdAfterForm = wrapper.find('input#input-created-after');
+    let createdBeforeForm = wrapper.find('input#input-created-before');
+
+    await createdAfterForm.setValue('2021-01-05');
+    await createdBeforeForm.setValue('2021-09-13');
+
+    expect(wrapper.vm.semesterSelection).toBe('');
+
+    // Simulate updating the submitted_after date back to a valid semester boundary
+    await createdAfterForm.setValue('2021-02-01');
+
+    expect(wrapper.vm.semesterSelection).toBe('');
+    
+    // Simulate updating both to valid semester boundaries
+    await createdAfterForm.setValue('2021-02-01');
+    await createdBeforeForm.setValue('2021-07-31');
+
+    expect(wrapper.vm.semesterSelection).toBe('2021A');
+
   });
 });


### PR DESCRIPTION
This PR adds an "exclude state" filter and makes state/exclude states multiple selection filters. Also added is a Semester dropdown with a list of past semesters which  when selected, fills in the submitted_after and submitted_before fields as a starting point.

I'm able to run this locally, but for some reason when running at my machine at the office it's painfully slow when accessing from outside (?!?!?), so I am unable to link you to a functional live page :( I am happy to demo this, however! It's not too much different from what I showed late last week.

Here's the updated filter
![image](https://user-images.githubusercontent.com/7182533/112386556-5862cc00-8cae-11eb-9870-fe73de2a729c.png)

Observation portal PR: https://github.com/observatorycontrolsystem/observation-portal/pull/188