### PR TITLE
Fix npm install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Some components in the library depend on [Vue Router](https://router.vuejs.org/)
 
 ### Installation
 ```
-npm install ocs-component-library
+npm install ocs-component-lib
 ```
 
 ### Using the components


### PR DESCRIPTION
Simple change: `npm install ocs-component-library` should be `npm install ocs-component-lib`.