### PR TITLE
Handle repeat offsets

### DIFF
--- a/src/components/Plots/DitherPatternPlot.vue
+++ b/src/components/Plots/DitherPatternPlot.vue
@@ -142,9 +142,17 @@ export default {
     offsetCoordinates: function() {
       // Calculate list of coordinates from provided offsets. Equations pulled
       // from https://www.atnf.csiro.au/computing/software/miriad/doc/offset.html
+      // If any adjacent offsets are the same, only add one coordinate to the list
+      // for that offset so that the same pointing is not plotted twice.
       let coords = [];
+      let lastOffset;
+      let isSameOffset = false;
       for (let offset of this.offsets) {
-        coords.push([this.centerRa + offset['ra'] / this.arcSecPerDeg / this.cosDec, this.centerDec + offset['dec'] / this.arcSecPerDeg]);
+        isSameOffset = lastOffset && offset['ra'] === lastOffset['ra'] && offset['dec'] === lastOffset['dec'];
+        if (!isSameOffset) {
+          coords.push([this.centerRa + offset['ra'] / this.arcSecPerDeg / this.cosDec, this.centerDec + offset['dec'] / this.arcSecPerDeg]);
+        }
+        lastOffset = { ra: offset['ra'], dec: offset['dec'] };
       }
       return coords;
     },

--- a/src/components/RequestGroupComposition/Configuration.vue
+++ b/src/components/RequestGroupComposition/Configuration.vue
@@ -260,6 +260,7 @@
                     <div class="dither-offset-table">
                       <b-table-lite :items="ditherPatternOffsets" :fields="dither.fields" small></b-table-lite>
                     </div>
+                    <p class="float-right px-3 mt-1 mb-4 font-weight-bolder">{{ ditherPatternOffsets.length }} offsets</p>
                     <br />
                   </template>
                 </dither-pattern-plot>
@@ -344,7 +345,7 @@ import Target from '@/components/RequestGroupComposition/Target.vue';
 import DitherPatternPlot from '@/components/Plots/DitherPatternPlot.vue';
 import DataLoader from '@/components/Util/DataLoader.vue';
 import { collapseMixin } from '@/mixins/collapseMixins.js';
-import { getFromObject, defaultTooltipConfig } from '@/util';
+import { getFromObject, defaultTooltipConfig, objAsString } from '@/util';
 
 export default {
   name: 'Configuration',
@@ -365,16 +366,7 @@ export default {
       return Number(value);
     },
     objAsString(value) {
-      let result = '';
-      for (let key in value) {
-        if (result) {
-          result += `, ${key}: ${value[key]}`;
-        } else {
-          // This is the first key, value pair being printed
-          result += `${key}: ${value[key]}`;
-        }
-      }
-      return result;
+      return objAsString(value);
     }
   },
   mixins: [collapseMixin],
@@ -468,7 +460,15 @@ export default {
       dither: {
         fields: [
           { key: 'ra', label: 'RA offset (arcsec)' },
-          { key: 'dec', label: 'Dec offset (arcsec)' }
+          { key: 'dec', label: 'Dec offset (arcsec)' },
+          { key: 'exposure_time', label: 'Exposure Time (s)' },
+          {
+            key: 'optical_elements',
+            label: 'Optical Elements',
+            formatter: value => {
+              return objAsString(value);
+            }
+          }
         ],
         pattern: _.get(this.ditherPatternOptions, [0, 'value'], 'none'),
         centerOptions: [
@@ -597,7 +597,9 @@ export default {
       for (let instrumentConfig of this.dither.expandedInstrumentConfigs) {
         offsets.push({
           ra: instrumentConfig.extra_params.offset_ra,
-          dec: instrumentConfig.extra_params.offset_dec
+          dec: instrumentConfig.extra_params.offset_dec,
+          exposure_time: instrumentConfig.exposure_time,
+          optical_elements: instrumentConfig.optical_elements
         });
       }
       return offsets;

--- a/src/util.js
+++ b/src/util.js
@@ -215,6 +215,19 @@ function round(value, decimalPlaces) {
   return Math.round(value * factor) / factor;
 }
 
+function objAsString(value) {
+  let result = '';
+  for (let key in value) {
+    if (result) {
+      result += `, ${key}: ${value[key]}`;
+    } else {
+      // This is the first key, value pair being printed
+      result += `${key}: ${value[key]}`;
+    }
+  }
+  return result;
+}
+
 export {
   copyObject,
   decimalDecToSexigesimal,
@@ -228,6 +241,7 @@ export {
   formatValue,
   generateDurationString,
   getFromObject,
+  objAsString,
   round,
   sexagesimalDecToDecimal,
   sexagesimalRaToDecimal,


### PR DESCRIPTION
Dither plot improvements when dither offsets are generated from multiple instrument configs.

- Add some more information to the dither offset table to show differences between items in the table when offsets are repeated. I figured exposure time and optical elements are the most likely things to change but can easily add other things to the table if you think including some other fields would be helpful.
- Don't plot the same offset more than once since the plot ended up looking a bit wonky when the same offset was plotted more than once, especially for the first and last dither pointings since they use different markers on the plot.