### PR TITLE
Optimize mosaic frontend

### DIFF
--- a/src/components/Plots/AladinPlot.vue
+++ b/src/components/Plots/AladinPlot.vue
@@ -16,6 +16,9 @@
 </template>
 <script>
 import $ from 'jquery';
+import { inject } from '@vue/composition-api';
+
+import { defaultAladinScriptLocation, defaultAladinStyleLocation } from '@/util';
 
 export default {
   name: 'AladinPlot',
@@ -32,15 +35,12 @@ export default {
     plotHeight: {
       type: String,
       default: '400px'
-    },
-    aladinScriptLocation: {
-      type: String,
-      default: 'https://aladin.u-strasbg.fr/AladinLite/api/v2/latest/aladin.min.js'
-    },
-    aladinStyleLocation: {
-      type: String,
-      default: 'https://aladin.u-strasbg.fr/AladinLite/api/v2/latest/aladin.min.css'
     }
+  },
+  setup: function() {
+    const aladinScriptLocation = inject('aladinScriptLocation', defaultAladinScriptLocation);
+    const aladinStyleLocation = inject('aladinStyleLocation', defaultAladinStyleLocation);
+    return { aladinScriptLocation, aladinStyleLocation };
   },
   data: function() {
     return {

--- a/src/components/Plots/DitherPatternPlot.vue
+++ b/src/components/Plots/DitherPatternPlot.vue
@@ -12,8 +12,6 @@
           :plot-height="plotHeight"
           :plot-width="plotWidth"
           class="aladin-responsive"
-          :aladin-script-location="aladinScriptLocation"
-          :aladin-style-location="aladinStyleLocation"
           @aladin-loaded="onZoomedOutPlotLoaded"
         />
         <div class="text-center font-italic m-auto w-100">
@@ -27,8 +25,6 @@
           :plot-height="plotHeight"
           :plot-width="plotWidth"
           class="aladin-responsive"
-          :aladin-script-location="aladinScriptLocation"
-          :aladin-style-location="aladinStyleLocation"
           @aladin-loaded="onZoomedInPlotLoaded"
         />
         <div class="text-center font-italic m-auto w-100">
@@ -106,14 +102,6 @@ export default {
     patternType: {
       type: String,
       required: true
-    },
-    aladinScriptLocation: {
-      type: String,
-      default: 'https://aladin.u-strasbg.fr/AladinLite/api/v2/latest/aladin.min.js'
-    },
-    aladinStyleLocation: {
-      type: String,
-      default: 'https://aladin.u-strasbg.fr/AladinLite/api/v2/latest/aladin.min.css'
     }
   },
   data: function() {

--- a/src/components/Plots/MosaicPlot.vue
+++ b/src/components/Plots/MosaicPlot.vue
@@ -12,8 +12,6 @@
           :plot-height="plotHeight"
           :plot-width="plotWidth"
           class="aladin-responsive"
-          :aladin-script-location="aladinScriptLocation"
-          :aladin-style-location="aladinStyleLocation"
           @aladin-loaded="onAladinLoaded"
         />
         <div class="text-center font-italic m-auto w-100">
@@ -27,6 +25,7 @@
 <script>
 /* global A */
 import _ from 'lodash';
+import { inject } from '@vue/composition-api';
 
 import AladinPlot from '@/components/Plots/AladinPlot.vue';
 import {
@@ -59,22 +58,13 @@ export default {
     instrumentsInfo: {
       type: Object,
       required: true
-    },
-    extraInstrumentRotation: {
-      type: Function,
-      // eslint-disable-next-line no-unused-vars
-      default: configuration => {
-        return 0;
-      }
-    },
-    aladinScriptLocation: {
-      type: String,
-      default: 'https://aladin.u-strasbg.fr/AladinLite/api/v2/latest/aladin.min.js'
-    },
-    aladinStyleLocation: {
-      type: String,
-      default: 'https://aladin.u-strasbg.fr/AladinLite/api/v2/latest/aladin.min.css'
     }
+  },
+  setup: function() {
+    const extraInstrumentRotation = inject('mosaicExtraInstrumentRotation');
+    return {
+      extraInstrumentRotation
+    };
   },
   data: function() {
     let instrumentType = this.configurations[0].instrument_type;

--- a/src/components/RequestGroupComposition/Configuration.vue
+++ b/src/components/RequestGroupComposition/Configuration.vue
@@ -9,7 +9,6 @@
     :errors="errors"
     :show="show"
     :index="index"
-    :tooltip-config="tooltipConfig"
     @remove="$emit('remove')"
     @copy="$emit('copy')"
     @show="show = $event"
@@ -31,7 +30,6 @@
               :desc="getFromObject(formConfig, ['configuration', 'instrument_category', 'desc'], '')"
               :hide="getFromObject(formConfig, ['configuration', 'instrument_category', 'hide'], false)"
               :options="instrumentCategoryOptions"
-              :tooltip-config="tooltipConfig"
               :errors="{}"
               @change="onInstrumentCategoryChange"
             />
@@ -42,7 +40,6 @@
               :desc="getFromObject(formConfig, ['configuration', 'instrument_type', 'desc'], '')"
               :hide="getFromObject(formConfig, ['configuration', 'instrument_type', 'hide'], false)"
               :errors="errors.instrument_type"
-              :tooltip-config="tooltipConfig"
               :options="availableInstrumentOptions"
               @change="onInstrumentTypeChange"
             />
@@ -53,7 +50,6 @@
               :desc="getFromObject(formConfig, ['guidingConfig', 'mode', 'desc'], '')"
               :hide="getFromObject(formConfig, ['guidingConfig', 'mode', 'hide'], false)"
               :errors="{}"
-              :tooltip-config="tooltipConfig"
               :options="guideModeOptions"
               @input="update"
             >
@@ -77,7 +73,6 @@
               :desc="getFromObject(formConfig, ['configuration', 'type', 'desc'], '')"
               :hide="getFromObject(formConfig, ['configuration', 'type', 'hide'], false)"
               :errors="errors.type"
-              :tooltip-config="tooltipConfig"
               :options="configurationTypeOptions"
               @input="update"
             />
@@ -88,7 +83,6 @@
                 :label="getFromObject(formConfig, ['configuration', 'repeat_duration', 'label'], 'Duration')"
                 :desc="getFromObject(formConfig, ['configuration', 'repeat_duration', 'desc'], '')"
                 :hide="getFromObject(formConfig, ['configuration', 'repeat_duration', 'hide'], false)"
-                :tooltip-config="tooltipConfig"
                 :errors="errors.repeat_duration"
                 @input="update"
               >
@@ -106,7 +100,6 @@
               :label="getFromObject(formConfig, ['acquisitionConfig', 'mode', 'label'], 'Acquire Mode')"
               :desc="getFromObject(formConfig, ['acquisitionConfig', 'mode', 'desc'], '')"
               :hide="getFromObject(formConfig, ['acquisitionConfig', 'mode', 'hide'], false)"
-              :tooltip-config="tooltipConfig"
               :errors="{}"
               :options="acquireModeOptions"
               @input="update"
@@ -119,7 +112,6 @@
               :label="getFromObject(formConfig, ['acquisitionConfig', field, 'label'], field)"
               :desc="getFromObject(formConfig, ['acquisitionConfig', field, 'desc'], '')"
               :hide="getFromObject(formConfig, ['acquisitionConfig', field, 'hide'], false)"
-              :tooltip-config="tooltipConfig"
               :errors="null"
               @input="updateAcquisitionConfigExtraParam($event, field)"
             />
@@ -140,7 +132,6 @@
               "
               :hide="getFromObject(formConfig, ['configuration', 'dither', 'hide'], !ditheringIsAllowed)"
               hide-when-collapsed
-              :tooltip-config="tooltipConfig"
               :errors="{}"
             />
             <custom-field
@@ -151,7 +142,6 @@
               :desc="getFromObject(formConfig, ['configuration', 'dither_num_points', 'desc'], 'Number of points in the pattern')"
               :hide="getFromObject(formConfig, ['configuration', 'dither_num_points', 'hide'], !ditheringIsAllowed)"
               hide-when-collapsed
-              :tooltip-config="tooltipConfig"
               :errors="null"
             />
             <custom-field
@@ -168,7 +158,6 @@
               "
               :hide="getFromObject(formConfig, ['configuration', 'dither_point_spacing', 'hide'], !ditheringIsAllowed)"
               hide-when-collapsed
-              :tooltip-config="tooltipConfig"
               :errors="null"
             />
             <custom-field
@@ -185,7 +174,6 @@
               "
               :hide="getFromObject(formConfig, ['configuration', 'dither_line_spacing', 'hide'], !ditheringIsAllowed)"
               hide-when-collapsed
-              :tooltip-config="tooltipConfig"
               :errors="null"
             />
             <custom-field
@@ -202,7 +190,6 @@
               "
               :hide="getFromObject(formConfig, ['configuration', 'dither_orientation', 'hide'], !ditheringIsAllowed)"
               hide-when-collapsed
-              :tooltip-config="tooltipConfig"
               :errors="null"
             />
             <custom-field
@@ -219,7 +206,6 @@
               "
               :hide="getFromObject(formConfig, ['configuration', 'dither_num_rows', 'hide'], !ditheringIsAllowed)"
               hide-when-collapsed
-              :tooltip-config="tooltipConfig"
               :errors="null"
             />
             <custom-field
@@ -236,7 +222,6 @@
               "
               :hide="getFromObject(formConfig, ['configuration', 'dither_num_columns', 'hide'], !ditheringIsAllowed)"
               hide-when-collapsed
-              :tooltip-config="tooltipConfig"
               :errors="null"
             />
             <custom-select
@@ -254,7 +239,6 @@
               "
               :hide="getFromObject(formConfig, ['configuration', 'dither_center', 'hide'], !ditheringIsAllowed)"
               hide-when-collapsed
-              :tooltip-config="tooltipConfig"
               :errors="null"
             />
             <b-form-group
@@ -303,8 +287,6 @@
                   :instrument-type="configuration.instrument_type"
                   :is-sidereal-target="configuration.target.type === 'ICRS'"
                   :pattern-type="dither.pattern"
-                  :aladin-script-location="aladinScriptLocation"
-                  :aladin-style-location="aladinStyleLocation"
                   show-help
                 >
                   <template #help>
@@ -343,7 +325,6 @@
       :dithering-is-allowed="ditheringIsAllowed"
       :errors="getFromObject(errors, ['instrument_configs', idx], {})"
       :form-config="formConfig"
-      :tooltip-config="tooltipConfig"
       @remove="removeInstrumentConfiguration(idx)"
       @copy="addInstrumentConfiguration(idx)"
       @instrumentconfigupdate="instumentConfigurationUpdated"
@@ -362,7 +343,6 @@
       :parent-show="show"
       :errors="getFromObject(errors, 'target', {})"
       :form-config="formConfig"
-      :tooltip-config="tooltipConfig"
       @target-updated="targetUpdated"
     >
       <template #target-help="data">
@@ -378,7 +358,6 @@
       :constraints="configuration.constraints"
       :parent-show="show"
       :form-config="formConfig"
-      :tooltip-config="tooltipConfig"
       :errors="getFromObject(errors, 'constraints', {})"
       @constraintsupdate="constraintsUpdated"
     >
@@ -390,6 +369,7 @@
 </template>
 <script>
 import _ from 'lodash';
+import { inject } from '@vue/composition-api';
 
 import FormPanel from '@/components/RequestGroupComposition/FormPanel.vue';
 import CustomAlert from '@/components/RequestGroupComposition/CustomAlert.vue';
@@ -402,7 +382,7 @@ import Target from '@/components/RequestGroupComposition/Target.vue';
 import DitherPatternPlot from '@/components/Plots/DitherPatternPlot.vue';
 import DataLoader from '@/components/Util/DataLoader.vue';
 import { collapseMixin } from '@/mixins/collapseMixins.js';
-import { getFromObject, defaultTooltipConfig, objAsString } from '@/util';
+import { getFromObject, objAsString } from '@/util';
 import requestExpansionWithModalConfirm from '@/composables/requestExpansionWithModalConfirm.js';
 
 export default {
@@ -470,45 +450,11 @@ export default {
         return {};
       }
     },
-    ditherPatternOptions: {
-      type: Array,
-      default: () => {
-        return [
-          { text: 'None', value: 'none' },
-          { text: 'Line', value: 'line' },
-          { text: 'Grid', value: 'grid' },
-          { text: 'Spiral', value: 'spiral' }
-        ];
-      }
-    },
-    // `ditheringAllowed` is a function that takes the configuration data, the request index, and the configuration index,
-    // and returns a boolean indicating whether dithering is allowed.
-    ditheringAllowed: {
-      type: Function,
-      // eslint-disable-next-line no-unused-vars
-      default: (configuration, requestIndex, configurationIndex) => {
-        return true;
-      }
-    },
-    tooltipConfig: {
-      type: Object,
-      default: () => {
-        return defaultTooltipConfig;
-      }
-    },
     formConfig: {
       type: Object,
       default: () => {
         return {};
       }
-    },
-    aladinScriptLocation: {
-      type: String,
-      default: 'https://aladin.u-strasbg.fr/AladinLite/api/v2/latest/aladin.min.js'
-    },
-    aladinStyleLocation: {
-      type: String,
-      default: 'https://aladin.u-strasbg.fr/AladinLite/api/v2/latest/aladin.min.css'
     }
   },
   data: function() {
@@ -550,6 +496,8 @@ export default {
     };
   },
   setup: function() {
+    const ditherPatternOptions = inject('ditherPatternOptions');
+    const ditheringAllowed = inject('ditheringAllowed');
     const {
       expansion,
       acceptExpansionForKeyOnObject,
@@ -564,7 +512,9 @@ export default {
       cancelExpansion,
       checkReadyToGenerateExpansion,
       generateExpansion,
-      getExpansionErrors
+      getExpansionErrors,
+      ditherPatternOptions,
+      ditheringAllowed
     };
   },
   computed: {

--- a/src/components/RequestGroupComposition/Configuration.vue
+++ b/src/components/RequestGroupComposition/Configuration.vue
@@ -501,7 +501,7 @@ export default {
   },
   data: function() {
     return {
-      show: true,
+      show: this.index === 0 ? this.parentShow : false,
       selectedInstrumentCategory: this.getInstrumentCategory(),
       position: {
         requestIndex: this.requestIndex,

--- a/src/components/RequestGroupComposition/Configuration.vue
+++ b/src/components/RequestGroupComposition/Configuration.vue
@@ -509,7 +509,7 @@ export default {
   },
   data: function() {
     return {
-      show: this.index === 0 ? this.parentShow : false,
+      show: this.parentShow,
       selectedInstrumentCategory: this.getInstrumentCategory(),
       position: {
         requestIndex: this.requestIndex,

--- a/src/components/RequestGroupComposition/Configuration.vue
+++ b/src/components/RequestGroupComposition/Configuration.vue
@@ -456,6 +456,10 @@ export default {
     parentShow: {
       type: Boolean
     },
+    initialShow: {
+      type: Boolean,
+      default: true
+    },
     durationData: {
       type: Object,
       required: true
@@ -509,7 +513,7 @@ export default {
   },
   data: function() {
     return {
-      show: this.parentShow,
+      show: this.initialShow,
       selectedInstrumentCategory: this.getInstrumentCategory(),
       position: {
         requestIndex: this.requestIndex,

--- a/src/components/RequestGroupComposition/Configuration.vue
+++ b/src/components/RequestGroupComposition/Configuration.vue
@@ -139,6 +139,7 @@
                 )
               "
               :hide="getFromObject(formConfig, ['configuration', 'dither', 'hide'], !ditheringIsAllowed)"
+              hide-when-collapsed
               :tooltip-config="tooltipConfig"
               :errors="{}"
             />
@@ -149,6 +150,7 @@
               :label="getFromObject(formConfig, ['configuration', 'dither_num_points', 'label'], 'Number of Points')"
               :desc="getFromObject(formConfig, ['configuration', 'dither_num_points', 'desc'], 'Number of points in the pattern')"
               :hide="getFromObject(formConfig, ['configuration', 'dither_num_points', 'hide'], !ditheringIsAllowed)"
+              hide-when-collapsed
               :tooltip-config="tooltipConfig"
               :errors="null"
             />
@@ -165,6 +167,7 @@
                 )
               "
               :hide="getFromObject(formConfig, ['configuration', 'dither_point_spacing', 'hide'], !ditheringIsAllowed)"
+              hide-when-collapsed
               :tooltip-config="tooltipConfig"
               :errors="null"
             />
@@ -181,6 +184,7 @@
                 )
               "
               :hide="getFromObject(formConfig, ['configuration', 'dither_line_spacing', 'hide'], !ditheringIsAllowed)"
+              hide-when-collapsed
               :tooltip-config="tooltipConfig"
               :errors="null"
             />
@@ -197,6 +201,7 @@
                 )
               "
               :hide="getFromObject(formConfig, ['configuration', 'dither_orientation', 'hide'], !ditheringIsAllowed)"
+              hide-when-collapsed
               :tooltip-config="tooltipConfig"
               :errors="null"
             />
@@ -213,6 +218,7 @@
                 )
               "
               :hide="getFromObject(formConfig, ['configuration', 'dither_num_rows', 'hide'], !ditheringIsAllowed)"
+              hide-when-collapsed
               :tooltip-config="tooltipConfig"
               :errors="null"
             />
@@ -229,6 +235,7 @@
                 )
               "
               :hide="getFromObject(formConfig, ['configuration', 'dither_num_columns', 'hide'], !ditheringIsAllowed)"
+              hide-when-collapsed
               :tooltip-config="tooltipConfig"
               :errors="null"
             />
@@ -246,6 +253,7 @@
                 )
               "
               :hide="getFromObject(formConfig, ['configuration', 'dither_center', 'hide'], !ditheringIsAllowed)"
+              hide-when-collapsed
               :tooltip-config="tooltipConfig"
               :errors="null"
             />

--- a/src/components/RequestGroupComposition/Configuration.vue
+++ b/src/components/RequestGroupComposition/Configuration.vue
@@ -939,8 +939,6 @@ export default {
           return !_.isEmpty(this.errors);
         })
       ) {
-        // The returned instrument configs do not include any field indicating that they belong to a dither sequence, other than the offset_ra
-        // and offset_dec fields in the extra params so this information might need to be added if it is included in the API response in the future.
         this.generateExpansion(
           `${this.observationPortalApiBaseUrl}/api/configurations/dither/`,
           this.getDitherParameters(false),

--- a/src/components/RequestGroupComposition/Configuration.vue
+++ b/src/components/RequestGroupComposition/Configuration.vue
@@ -279,7 +279,7 @@
               header="Generated Dither Pattern"
               :show-accept="expansion.expanded.length > 0"
               @close="cancelExpansion"
-              @submit="acceptExpansionForKeyOnObject(configuration, 'instrument_configs')"
+              @submit="acceptExpansionForKeyOnObject(configuration, 'instrument_configs', { addExtraInfo: true })"
             >
               <data-loader
                 :data-loaded="expansion.status.loaded"
@@ -941,9 +941,14 @@ export default {
       ) {
         // The returned instrument configs do not include any field indicating that they belong to a dither sequence, other than the offset_ra
         // and offset_dec fields in the extra params so this information might need to be added if it is included in the API response in the future.
-        this.generateExpansion(`${this.observationPortalApiBaseUrl}/api/configurations/dither/`, this.getDitherParameters(false), response => {
-          return response.instrument_configs;
-        });
+        this.generateExpansion(
+          `${this.observationPortalApiBaseUrl}/api/configurations/dither/`,
+          this.getDitherParameters(false),
+          response => {
+            return response.instrument_configs;
+          },
+          { saveExtraInfo: true }
+        );
       }
     }
   }

--- a/src/components/RequestGroupComposition/Constraints.vue
+++ b/src/components/RequestGroupComposition/Constraints.vue
@@ -98,7 +98,7 @@ export default {
   },
   data: function() {
     return {
-      show: true,
+      show: this.parentShow,
       position: {
         requestIndex: this.requestIndex,
         configurationIndex: this.configurationIndex

--- a/src/components/RequestGroupComposition/Constraints.vue
+++ b/src/components/RequestGroupComposition/Constraints.vue
@@ -8,7 +8,6 @@
     :can-remove="false"
     :errors="errors"
     :show="show"
-    :tooltip-config="tooltipConfig"
     @show="show = $event"
   >
     <custom-alert v-for="error in errors.non_field_errors" :key="error" alert-class="danger" :dismissible="false">
@@ -27,7 +26,6 @@
               :label="getFromObject(formConfig, ['constraints', 'max_airmass', 'label'], 'Maximum Airmass')"
               :desc="getFromObject(formConfig, ['constraints', 'max_airmass', 'desc'], '')"
               :hide="getFromObject(formConfig, ['constraints', 'max_airmass', 'hide'], false)"
-              :tooltip-config="tooltipConfig"
               :errors="errors.max_airmass"
               @input="update"
             />
@@ -37,7 +35,6 @@
               :label="getFromObject(formConfig, ['constraints', 'min_lunar_distance', 'label'], 'Minimum Lunar Separation')"
               :desc="getFromObject(formConfig, ['constraints', 'min_lunar_distance', 'desc'], '')"
               :hide="getFromObject(formConfig, ['constraints', 'min_lunar_distance', 'hide'], false)"
-              :tooltip-config="tooltipConfig"
               :errors="errors.min_lunar_distance"
               @input="update"
             />
@@ -53,7 +50,7 @@ import CustomAlert from '@/components/RequestGroupComposition/CustomAlert.vue';
 import CustomField from '@/components/RequestGroupComposition/CustomField.vue';
 
 import { collapseMixin } from '@/mixins/collapseMixins.js';
-import { getFromObject, defaultTooltipConfig } from '@/util';
+import { getFromObject } from '@/util';
 
 export default {
   name: 'Constraints',
@@ -79,12 +76,6 @@ export default {
     errors: {
       type: Object,
       required: true
-    },
-    tooltipConfig: {
-      type: Object,
-      default: () => {
-        return defaultTooltipConfig;
-      }
     },
     parentShow: {
       type: Boolean

--- a/src/components/RequestGroupComposition/CustomDatetime.vue
+++ b/src/components/RequestGroupComposition/CustomDatetime.vue
@@ -39,6 +39,7 @@
 import _ from 'lodash';
 import VueCtkDateTimePicker from 'vue-ctk-date-time-picker';
 import 'vue-ctk-date-time-picker/dist/vue-ctk-date-time-picker.css';
+import { inject } from '@vue/composition-api';
 
 import { defaultTooltipConfig, defaultDatetimeFormat } from '@/util';
 
@@ -55,10 +56,6 @@ export default {
     label: {
       type: String,
       default: ''
-    },
-    datetimeFormat: {
-      type: String,
-      default: defaultDatetimeFormat
     },
     field: {
       type: String,
@@ -82,13 +79,18 @@ export default {
     desc: {
       type: String,
       default: ''
-    },
-    tooltipConfig: {
-      type: Object,
-      default: () => {
-        return defaultTooltipConfig;
-      }
     }
+  },
+  setup: function() {
+    const tooltipConfig = inject(
+      'tooltipConfig',
+      () => {
+        return defaultTooltipConfig;
+      },
+      true
+    );
+    const datetimeFormat = inject('datetimeFormat', defaultDatetimeFormat);
+    return { tooltipConfig, datetimeFormat };
   },
   computed: {
     hasErrors: function() {

--- a/src/components/RequestGroupComposition/CustomDatetime.vue
+++ b/src/components/RequestGroupComposition/CustomDatetime.vue
@@ -1,7 +1,7 @@
 <template>
   <span v-if="!hide">
     <b-form-group
-      v-show="$parent.show"
+      v-if="$parent.show"
       :id="field + '-datetimegroup-' + $parent.id"
       label-size="sm"
       label-align-sm="right"
@@ -30,7 +30,7 @@
         {{ error }}
       </span>
     </b-form-group>
-    <span v-show="!$parent.show" class="mr-4">
+    <span v-if="!hideWhenCollapsed && !$parent.show" class="mr-4" :class="collapsedValidationStyle">
       {{ label }}: <strong>{{ value || '...' }}</strong>
     </span>
   </span>
@@ -69,6 +69,10 @@ export default {
     hide: {
       type: Boolean
     },
+    // Hide this field when collapsed
+    hideWhenCollapsed: {
+      type: Boolean
+    },
     errors: {
       validator: function(value) {
         return value === undefined || value === null || typeof value === 'object';
@@ -89,6 +93,11 @@ export default {
   computed: {
     hasErrors: function() {
       return !_.isEmpty(this.errors);
+    },
+    collapsedValidationStyle: function() {
+      return {
+        'text-danger': this.hasErrors
+      };
     }
   },
   methods: {

--- a/src/components/RequestGroupComposition/CustomField.vue
+++ b/src/components/RequestGroupComposition/CustomField.vue
@@ -39,6 +39,7 @@
 </template>
 <script>
 import _ from 'lodash';
+import { inject } from '@vue/composition-api';
 
 import { defaultTooltipConfig } from '@/util';
 
@@ -83,13 +84,17 @@ export default {
     desc: {
       type: String,
       default: ''
-    },
-    tooltipConfig: {
-      type: Object,
-      default: () => {
-        return defaultTooltipConfig;
-      }
     }
+  },
+  setup: function() {
+    const tooltipConfig = inject(
+      'tooltipConfig',
+      () => {
+        return defaultTooltipConfig;
+      },
+      true
+    );
+    return { tooltipConfig };
   },
   computed: {
     hasErrors: function() {

--- a/src/components/RequestGroupComposition/CustomField.vue
+++ b/src/components/RequestGroupComposition/CustomField.vue
@@ -1,10 +1,10 @@
 <template>
   <span v-if="!hide">
-    <span class="text-right font-italic extra-help-text">
+    <span v-if="$parent.show" class="text-right font-italic extra-help-text">
       <slot name="extra-help-text" />
     </span>
     <b-form-group
-      v-show="$parent.show"
+      v-if="$parent.show"
       :id="field + '-fieldgroup-' + $parent.id"
       label-size="sm"
       label-align-sm="right"
@@ -32,7 +32,7 @@
         {{ error }}
       </span>
     </b-form-group>
-    <span v-show="!$parent.show" class="mr-4">
+    <span v-if="!hideWhenCollapsed && !$parent.show" class="mr-4" :class="collapsedValidationStyle">
       {{ label }}: <strong>{{ displayValue(value) }}</strong>
     </span>
   </span>
@@ -56,6 +56,10 @@ export default {
       required: true
     },
     hide: {
+      type: Boolean
+    },
+    // Hide this field when collapsed
+    hideWhenCollapsed: {
       type: Boolean
     },
     field: {
@@ -100,6 +104,11 @@ export default {
       } else {
         return null;
       }
+    },
+    collapsedValidationStyle: function() {
+      return {
+        'text-danger': this.validationState === null ? false : true
+      };
     }
   },
   methods: {

--- a/src/components/RequestGroupComposition/CustomSelect.vue
+++ b/src/components/RequestGroupComposition/CustomSelect.vue
@@ -1,10 +1,10 @@
 <template>
   <span v-if="!hide">
-    <span class="text-right font-italic extra-help-text">
+    <span v-if="$parent.show" class="text-right font-italic extra-help-text">
       <slot name="extra-help-text" />
     </span>
     <b-form-group
-      v-show="$parent.show"
+      v-if="$parent.show"
       :id="field + '-fieldgroup-' + $parent.id"
       label-size="sm"
       label-align-sm="right"
@@ -32,7 +32,7 @@
         {{ error }}
       </span>
     </b-form-group>
-    <span v-show="!$parent.show" class="mr-4">
+    <span v-if="!hideWhenCollapsed && !$parent.show" class="mr-4" :class="collapsedValidationStyle">
       {{ label }}: <strong>{{ value || '...' }}</strong>
     </span>
   </span>
@@ -88,6 +88,10 @@ export default {
       type: String,
       default: ''
     },
+    // Hide this field when collapsed
+    hideWhenCollapsed: {
+      type: Boolean
+    },
     // Setting this to `true` will ensure that all string options that are passed in are lowercased
     lowerOptions: {
       type: Boolean
@@ -112,6 +116,11 @@ export default {
       } else {
         return null;
       }
+    },
+    collapsedValidationStyle: function() {
+      return {
+        'text-danger': this.validationState === null ? false : true
+      };
     },
     selectOptions: function() {
       if (this.lowerOptions) {

--- a/src/components/RequestGroupComposition/CustomSelect.vue
+++ b/src/components/RequestGroupComposition/CustomSelect.vue
@@ -39,6 +39,7 @@
 </template>
 <script>
 import _ from 'lodash';
+import { inject } from '@vue/composition-api';
 
 import { defaultTooltipConfig } from '@/util';
 
@@ -95,13 +96,17 @@ export default {
     // Setting this to `true` will ensure that all string options that are passed in are lowercased
     lowerOptions: {
       type: Boolean
-    },
-    tooltipConfig: {
-      type: Object,
-      default: () => {
-        return defaultTooltipConfig;
-      }
     }
+  },
+  setup: function() {
+    const tooltipConfig = inject(
+      'tooltipConfig',
+      () => {
+        return defaultTooltipConfig;
+      },
+      true
+    );
+    return { tooltipConfig };
   },
   computed: {
     hasErrors: function() {

--- a/src/components/RequestGroupComposition/FormPanel.vue
+++ b/src/components/RequestGroupComposition/FormPanel.vue
@@ -64,6 +64,7 @@
 </template>
 <script>
 import _ from 'lodash';
+import { inject } from '@vue/composition-api';
 
 import { defaultTooltipConfig } from '@/util';
 import { confirmMixin } from '@/mixins/confirmMixins';
@@ -103,13 +104,17 @@ export default {
     index: {
       type: Number,
       default: 0
-    },
-    tooltipConfig: {
-      type: Object,
-      default: () => {
-        return defaultTooltipConfig;
-      }
     }
+  },
+  setup: function() {
+    const tooltipConfig = inject(
+      'tooltipConfig',
+      () => {
+        return defaultTooltipConfig;
+      },
+      true
+    );
+    return { tooltipConfig };
   },
   computed: {
     hasError: function() {

--- a/src/components/RequestGroupComposition/InstrumentConfigForm.vue
+++ b/src/components/RequestGroupComposition/InstrumentConfigForm.vue
@@ -33,7 +33,7 @@
       :errors="errors.mode"
       @input="update"
     />
-    <div v-for="opticalElementGroup in availableOpticalElementGroups" :key="opticalElementGroup.type">
+    <div v-for="opticalElementGroup in availableOpticalElementGroups" :key="opticalElementGroup.type" class="d-inline">
       <custom-select
         v-model="instrumentConfig.optical_elements[opticalElementGroup.type]"
         :field="opticalElementGroup.type"
@@ -47,7 +47,7 @@
         @input="updateOpticalElement"
       />
     </div>
-    <div v-if="rotatorModeOptions.length > 0">
+    <div v-if="rotatorModeOptions.length > 0" class="d-inline">
       <custom-select
         v-model="instrumentConfig.rotator_mode"
         field="rotator_mode"

--- a/src/components/RequestGroupComposition/InstrumentConfigForm.vue
+++ b/src/components/RequestGroupComposition/InstrumentConfigForm.vue
@@ -7,7 +7,6 @@
       :desc="getFromObject(formConfig, ['instrumentConfig', 'exposure_count', 'desc'], '')"
       :hide="getFromObject(formConfig, ['instrumentConfig', 'exposure_count', 'hide'], false)"
       type="number"
-      :tooltip-config="tooltipConfig"
       :errors="errors.exposure_count"
       @input="update"
     />
@@ -17,7 +16,6 @@
       :label="getFromObject(formConfig, ['instrumentConfig', 'exposure_time', 'label'], 'Exposure Time')"
       :desc="getFromObject(formConfig, ['instrumentConfig', 'exposure_time', 'desc'], '')"
       :hide="getFromObject(formConfig, ['instrumentConfig', 'exposure_time', 'hide'], false)"
-      :tooltip-config="tooltipConfig"
       :errors="errors.exposure_time"
       @input="update"
     />
@@ -29,7 +27,6 @@
       :desc="getFromObject(formConfig, ['instrumentConfig', 'readout_mode', 'desc'], '')"
       :hide="getFromObject(formConfig, ['instrumentConfig', 'readout_mode', 'hide'], false)"
       :options="readoutModeOptions"
-      :tooltip-config="tooltipConfig"
       :errors="errors.mode"
       @input="update"
     />
@@ -42,7 +39,6 @@
         :hide="getFromObject(formConfig, ['instrumentConfig', opticalElementGroup.type, 'hide'], false)"
         :options="opticalElementGroup.options"
         lower-options
-        :tooltip-config="tooltipConfig"
         :errors="{}"
         @input="updateOpticalElement"
       />
@@ -54,7 +50,6 @@
         :label="getFromObject(formConfig, ['instrumentConfig', 'rotator_mode', 'label'], 'Rotator Mode')"
         :desc="getFromObject(formConfig, ['instrumentConfig', 'rotator_mode', 'desc'], '')"
         :hide="getFromObject(formConfig, ['instrumentConfig', 'rotator_mode', 'hide'], false)"
-        :tooltip-config="tooltipConfig"
         :errors="errors.rotator_mode"
         :options="rotatorModeOptions"
         @input="update"
@@ -67,7 +62,6 @@
         :label="getFromObject(formConfig, ['instrumentConfig', field, 'label'], field)"
         :desc="getFromObject(formConfig, ['instrumentConfig', field, 'desc'], '')"
         :hide="getFromObject(formConfig, ['instrumentConfig', field, 'desc'], false)"
-        :tooltip-config="tooltipConfig"
         :errors="null"
         @input="updateInstrumentConfigExtraParam($event, field)"
       />
@@ -98,7 +92,7 @@ import { toRef } from '@vue/composition-api';
 import baseInstrumentConfig from '@/composables/baseInstrumentConfig.js';
 import CustomField from '@/components/RequestGroupComposition/CustomField.vue';
 import CustomSelect from '@/components/RequestGroupComposition/CustomSelect.vue';
-import { getFromObject, defaultTooltipConfig } from '@/util';
+import { getFromObject } from '@/util';
 
 export default {
   name: 'InstrumentConfigForm',
@@ -133,12 +127,6 @@ export default {
     },
     show: {
       type: Boolean
-    },
-    tooltipConfig: {
-      type: Object,
-      default: () => {
-        return defaultTooltipConfig;
-      }
     },
     formConfig: {
       type: Object,

--- a/src/components/RequestGroupComposition/InstrumentConfigPanel.vue
+++ b/src/components/RequestGroupComposition/InstrumentConfigPanel.vue
@@ -93,7 +93,7 @@ export default {
     ditheringIsAllowed: {
       type: Boolean
     },
-    show: {
+    parentShow: {
       type: Boolean
     },
     tooltipConfig: {
@@ -111,6 +111,7 @@ export default {
   },
   data: function() {
     return {
+      show: this.parentShow,
       position: {
         requestIndex: this.requestIndex,
         configurationIndex: this.configurationIndex,

--- a/src/components/RequestGroupComposition/InstrumentConfigPanel.vue
+++ b/src/components/RequestGroupComposition/InstrumentConfigPanel.vue
@@ -9,7 +9,6 @@
     :errors="errors"
     :show="show"
     :index="index"
-    :tooltip-config="tooltipConfig"
     @remove="$emit('remove')"
     @copy="$emit('copy')"
     @show="show = $event"
@@ -36,7 +35,6 @@
               :selected-instrument="selectedInstrument"
               :available-instruments="availableInstruments"
               :errors="errors"
-              :tooltip-config="tooltipConfig"
               :form-config="formConfig"
               @instrument-config-update="update"
             />
@@ -50,7 +48,7 @@
 import InstrumentConfigForm from '@//components/RequestGroupComposition/InstrumentConfigForm.vue';
 import FormPanel from '@/components/RequestGroupComposition/FormPanel.vue';
 import CustomAlert from '@/components/RequestGroupComposition/CustomAlert.vue';
-import { extractTopLevelErrors, getFromObject, defaultTooltipConfig } from '@/util';
+import { extractTopLevelErrors, getFromObject } from '@/util';
 import { collapseMixin } from '@/mixins/collapseMixins.js';
 
 export default {
@@ -95,12 +93,6 @@ export default {
     },
     parentShow: {
       type: Boolean
-    },
-    tooltipConfig: {
-      type: Object,
-      default: () => {
-        return defaultTooltipConfig;
-      }
     },
     formConfig: {
       type: Object,

--- a/src/components/RequestGroupComposition/Request.vue
+++ b/src/components/RequestGroupComposition/Request.vue
@@ -320,7 +320,6 @@
 </template>
 <script>
 import _ from 'lodash';
-import Vue from 'vue';
 
 import Configuration from '@/components/RequestGroupComposition/Configuration.vue';
 import Window from '@/components/RequestGroupComposition/Window.vue';
@@ -674,7 +673,7 @@ export default {
       this.initialConfigurationShow = false;
       this.acceptExpansionForKeyOnObject(this.request, 'configurations', () => {
         // Expand the first configuration so that it looks nice.
-        Vue.nextTick(() => {
+        this.$nextTick(() => {
           for (let configuration of this.$refs.configurations) {
             if (configuration.position.configurationIndex === 0) {
               configuration.show = true;
@@ -682,7 +681,7 @@ export default {
           }
         });
         // Then, set configurations back to initially expand again.
-        Vue.nextTick(() => {
+        this.$nextTick(() => {
           this.initialConfigurationShow = true;
         });
       });

--- a/src/components/RequestGroupComposition/Request.vue
+++ b/src/components/RequestGroupComposition/Request.vue
@@ -200,13 +200,13 @@
               header="Generated Mosaic"
               :show-accept="expansion.expanded.length > 0"
               @close="cancelExpansion"
-              @submit="acceptExpansionForKeyOnObject(request, 'configurations')"
+              @submit="acceptMosaic()"
             >
               <data-loader
                 :data-loaded="expansion.status.loaded"
                 :data-not-found="expansion.status.notFound"
                 :data-load-error="expansion.status.error"
-                not-found-message="There are no pointing in the generated mosaic. Please update your mosaic parameters and try again."
+                not-found-message="There are no pointings in the generated mosaic. Please update your mosaic parameters and try again."
               >
                 <template #data-load-error>
                   <p>Unable to generate mosaic</p>
@@ -234,6 +234,7 @@
                     <div class="mosaic-offset-table">
                       <b-table-lite :items="mosaicTableItems" :fields="mosaic.fields" small></b-table-lite>
                     </div>
+                    <p class="float-right px-3 mt-1 mb-4 font-weight-bolder">{{ mosaicTableItems.length }} pointings</p>
                     <br />
                   </template>
                 </mosaic-plot>
@@ -246,6 +247,7 @@
     </b-container>
     <configuration
       v-for="(configuration, idx) in request.configurations"
+      ref="configurations"
       :key="'configuration' + idx"
       :index="idx"
       :request-index="index"
@@ -317,6 +319,7 @@
 </template>
 <script>
 import _ from 'lodash';
+import Vue from 'vue';
 
 import Configuration from '@/components/RequestGroupComposition/Configuration.vue';
 import Window from '@/components/RequestGroupComposition/Window.vue';
@@ -662,6 +665,19 @@ export default {
           return response.configurations;
         });
       }
+    },
+    acceptMosaic: function() {
+      this.acceptExpansionForKeyOnObject(this.request, 'configurations', () => {
+        Vue.nextTick(() => {
+          // Collapse all configurations within the expanded mosaic other than the first one
+          // so as not to overwhelm the webpage with too many new things to render.
+          for (let configuration of this.$refs.configurations) {
+            if (configuration.position.configurationIndex !== 0) {
+              configuration.show = false;
+            }
+          }
+        });
+      });
     }
   }
 };

--- a/src/components/RequestGroupComposition/Request.vue
+++ b/src/components/RequestGroupComposition/Request.vue
@@ -253,6 +253,7 @@
       :request-index="index"
       :configuration="configuration"
       :parent-show="show"
+      :initial-show="initialConfigurationShow"
       :observation-portal-api-base-url="observationPortalApiBaseUrl"
       :available-instruments="availableInstruments"
       :instrument-category-to-name="instrumentCategoryToName"
@@ -479,6 +480,7 @@ export default {
   data: function() {
     return {
       show: true,
+      initialConfigurationShow: true,
       mosaic: {
         fields: [
           { key: 'ra', label: 'Right ascension (decimal degrees)' },
@@ -667,15 +669,21 @@ export default {
       }
     },
     acceptMosaic: function() {
+      // Initialize the new configurations to be collapsed. Do this to keep rendering from taking a long time
+      // for large mosaic patterns.
+      this.initialConfigurationShow = false;
       this.acceptExpansionForKeyOnObject(this.request, 'configurations', () => {
+        // Expand the first configuration so that it looks nice.
         Vue.nextTick(() => {
-          // Collapse all configurations within the expanded mosaic other than the first one
-          // so as not to overwhelm the webpage with too many new things to render.
           for (let configuration of this.$refs.configurations) {
-            if (configuration.position.configurationIndex !== 0) {
-              configuration.show = false;
+            if (configuration.position.configurationIndex === 0) {
+              configuration.show = true;
             }
           }
+        });
+        // Then, set configurations back to initially expand again.
+        Vue.nextTick(() => {
+          this.initialConfigurationShow = true;
         });
       });
     }

--- a/src/components/RequestGroupComposition/Request.vue
+++ b/src/components/RequestGroupComposition/Request.vue
@@ -165,10 +165,25 @@
               label-size="sm"
               label-align-sm="right"
               label-cols-sm="4"
-              label=""
+              :label="getFromObject(formConfig, ['request', 'mosaic', 'label'], '')"
               label-for="mosaic-button"
+              :invalid-feedback="
+                getFromObject(
+                  formConfig,
+                  ['request', 'mosaic', 'invalid_parameters_feedback'],
+                  `The limit to the number of mosaic pointings that can be generated is ${mosaicMaxNumPointings}. Please
+                  update your parameters before generating a mosaic.`
+                )
+              "
+              :state="!tooManyMosaicPointings"
             >
-              <b-button :id="'mosaic-button-' + position.requestIndex" block variant="outline-primary" @click="generateMosaicPattern">
+              <b-button
+                :id="'mosaic-button-' + position.requestIndex"
+                block
+                variant="outline-primary"
+                :disabled="tooManyMosaicPointings"
+                @click="generateMosaicPattern"
+              >
                 Generate Mosaic
               </b-button>
             </b-form-group>
@@ -437,6 +452,10 @@ export default {
         return 0;
       }
     },
+    mosaicMaxNumPointings: {
+      type: Number,
+      default: 100
+    },
     aladinScriptLocation: {
       type: String,
       default: 'https://aladin.u-strasbg.fr/AladinLite/api/v2/latest/aladin.min.js'
@@ -507,6 +526,17 @@ export default {
         });
       }
       return pointings;
+    },
+    tooManyMosaicPointings: function() {
+      if (this.mosaic.pattern === 'grid') {
+        let numColumns = _.get(this.mosaic.parameters, ['numColumns'], 0);
+        let numRows = _.get(this.mosaic.parameters, ['numRows'], 0);
+        return numColumns * numRows > this.mosaicMaxNumPointings;
+      } else if (this.mosaic.pattern === 'line') {
+        let numPoints = _.get(this.mosaic.parameters, ['numPoints'], 0);
+        return numPoints > this.mosaicMaxNumPointings;
+      }
+      return false;
     }
   },
   methods: {

--- a/src/components/RequestGroupComposition/Request.vue
+++ b/src/components/RequestGroupComposition/Request.vue
@@ -179,7 +179,7 @@
                 getFromObject(
                   formConfig,
                   ['request', 'mosaic', 'invalid_parameters_feedback'],
-                  `The limit to the number of mosaic pointings that can be generated is ${mosaicMaxNumPointings}. Please
+                  `The limit to the number of mosaic pointings that can be generated in the frontend is ${mosaicMaxNumPointings}. Please
                   update your parameters before generating a mosaic.`
                 )
               "

--- a/src/components/RequestGroupComposition/Request.vue
+++ b/src/components/RequestGroupComposition/Request.vue
@@ -50,6 +50,7 @@
                 )
               "
               :hide="getFromObject(formConfig, ['request', 'mosaic', 'hide'], !mosaicIsAllowed)"
+              hide-when-collapsed
               :tooltip-config="tooltipConfig"
               :errors="{}"
             />
@@ -66,6 +67,7 @@
                 )
               "
               :hide="getFromObject(formConfig, ['request', 'mosaic_line_overlap_percent', 'hide'], !mosaicIsAllowed)"
+              hide-when-collapsed
               :tooltip-config="tooltipConfig"
               :errors="null"
             />
@@ -82,6 +84,7 @@
                 )
               "
               :hide="getFromObject(formConfig, ['request', 'mosaic_point_overlap_percent', 'hide'], !mosaicIsAllowed)"
+              hide-when-collapsed
               :tooltip-config="tooltipConfig"
               :errors="null"
             />
@@ -92,6 +95,7 @@
               :label="getFromObject(formConfig, ['request', 'mosaic_num_points', 'label'], 'Number of Points')"
               :desc="getFromObject(formConfig, ['request', 'mosaic_num_points', 'desc'], 'Number of points in the pattern')"
               :hide="getFromObject(formConfig, ['request', 'mosaic_num_points', 'hide'], !mosaicIsAllowed)"
+              hide-when-collapsed
               :tooltip-config="tooltipConfig"
               :errors="null"
             />
@@ -108,6 +112,7 @@
                 )
               "
               :hide="getFromObject(formConfig, ['request', 'mosaic_orientation', 'hide'], !mosaicIsAllowed)"
+              hide-when-collapsed
               :tooltip-config="tooltipConfig"
               :errors="null"
             />
@@ -124,6 +129,7 @@
                 )
               "
               :hide="getFromObject(formConfig, ['request', 'mosaic_num_rows', 'hide'], !mosaicIsAllowed)"
+              hide-when-collapsed
               :tooltip-config="tooltipConfig"
               :errors="null"
             />
@@ -140,6 +146,7 @@
                 )
               "
               :hide="getFromObject(formConfig, ['request', 'mosaic_num_columns', 'hide'], !mosaicIsAllowed)"
+              hide-when-collapsed
               :tooltip-config="tooltipConfig"
               :errors="null"
             />
@@ -157,6 +164,7 @@
                 )
               "
               :hide="getFromObject(formConfig, ['request', 'mosaic_center', 'hide'], !mosaicIsAllowed)"
+              hide-when-collapsed
               :tooltip-config="tooltipConfig"
               :errors="null"
             />

--- a/src/components/RequestGroupComposition/Request.vue
+++ b/src/components/RequestGroupComposition/Request.vue
@@ -662,28 +662,36 @@ export default {
           return !_.isEmpty(this.errors);
         })
       ) {
-        this.generateExpansion(`${this.observationPortalApiBaseUrl}/api/requests/mosaic/`, this.getMosaicParameters(false), response => {
-          return response.configurations;
-        });
+        this.generateExpansion(
+          `${this.observationPortalApiBaseUrl}/api/requests/mosaic/`,
+          this.getMosaicParameters(false),
+          response => {
+            return response.configurations;
+          },
+          { saveExtraInfo: true }
+        );
       }
     },
     acceptMosaic: function() {
       // Initialize the new configurations to be collapsed. Do this to keep rendering from taking a long time
       // for large mosaic patterns.
       this.initialConfigurationShow = false;
-      this.acceptExpansionForKeyOnObject(this.request, 'configurations', () => {
-        // Expand the first configuration so that it looks nice.
-        this.$nextTick(() => {
-          for (let configuration of this.$refs.configurations) {
-            if (configuration.position.configurationIndex === 0) {
-              configuration.show = true;
+      this.acceptExpansionForKeyOnObject(this.request, 'configurations', {
+        onDone: () => {
+          // Expand the first configuration so that it looks nice.
+          this.$nextTick(() => {
+            for (let configuration of this.$refs.configurations) {
+              if (configuration.position.configurationIndex === 0) {
+                configuration.show = true;
+              }
             }
-          }
-        });
-        // Then, set configurations back to initially expand again.
-        this.$nextTick(() => {
-          this.initialConfigurationShow = true;
-        });
+          });
+          // Then, set configurations back to initially expand again.
+          this.$nextTick(() => {
+            this.initialConfigurationShow = true;
+          });
+        },
+        addExtraInfo: true
       });
     }
   }

--- a/src/components/RequestGroupComposition/RequestGroup.vue
+++ b/src/components/RequestGroupComposition/RequestGroup.vue
@@ -115,6 +115,7 @@
         :mosaic-pattern-options="mosaicPatternOptions"
         :mosaic-allowed="mosaicAllowed"
         :mosaic-extra-instrument-rotation="mosaicExtraInstrumentRotation"
+        :mosaic-max-num-pointings="mosaicMaxNumPointings"
         :aladin-script-location="aladinScriptLocation"
         :aladin-style-location="aladinStyleLocation"
         :datetime-format="datetimeFormat"
@@ -264,6 +265,10 @@ export default {
       default: configuration => {
         return 0;
       }
+    },
+    mosaicMaxNumPointings: {
+      type: Number,
+      default: 100
     },
     observationTypeOptions: {
       type: Array,

--- a/src/components/RequestGroupComposition/RequestGroup.vue
+++ b/src/components/RequestGroupComposition/RequestGroup.vue
@@ -4,7 +4,6 @@
     id="general"
     :title="getFromObject(formConfig, ['requestGroup', 'panel', 'title'], 'Request Group')"
     :icon="getFromObject(formConfig, ['requestGroup', 'panel', 'icon'], 'fas fa-address-card')"
-    :tooltip-config="tooltipConfig"
     :can-remove="false"
     :can-copy="false"
     :errors="errors"
@@ -28,7 +27,6 @@
               :label="getFromObject(formConfig, ['requestGroup', 'name', 'label'], 'Name')"
               :desc="getFromObject(formConfig, ['requestGroup', 'name', 'desc'], '')"
               :hide="getFromObject(formConfig, ['requestGroup', 'name', 'hide'], false)"
-              :tooltip-config="tooltipConfig"
               :errors="errors.name"
               @input="update"
             />
@@ -38,7 +36,6 @@
               :label="getFromObject(formConfig, ['requestGroup', 'proposal', 'label'], 'Proposal')"
               :desc="getFromObject(formConfig, ['requestGroup', 'proposal', 'desc'], '')"
               :hide="getFromObject(formConfig, ['requestGroup', 'proposal', 'hide'], false)"
-              :tooltip-config="tooltipConfig"
               :errors="errors.proposal"
               :options="proposalOptions"
               @input="update"
@@ -49,7 +46,6 @@
               :label="getFromObject(formConfig, ['requestGroup', 'observation_type', 'label'], 'Observation Type')"
               :desc="getFromObject(formConfig, ['requestGroup', 'observation_type', 'desc'], '')"
               :hide="getFromObject(formConfig, ['requestGroup', 'observation_type', 'hide'], false)"
-              :tooltip-config="tooltipConfig"
               :errors="errors.observation_type"
               :options="observationTypeOptions"
               @input="update"
@@ -60,7 +56,6 @@
               :label="getFromObject(formConfig, ['requestGroup', 'ipp_value', 'label'], 'IPP Factor')"
               :desc="getFromObject(formConfig, ['requestGroup', 'ipp_value', 'desc'], '')"
               :hide="getFromObject(formConfig, ['requestGroup', 'ipp_value', 'hide'], false)"
-              :tooltip-config="tooltipConfig"
               :errors="errors.ipp_value"
               @input="update"
             />
@@ -110,17 +105,7 @@
         :site-code-to-name="siteCodeToName"
         :show-airmass-plot="showAirmassPlot"
         :instrument-category-to-name="instrumentCategoryToName"
-        :dither-pattern-options="ditherPatternOptions"
-        :dithering-allowed="ditheringAllowed"
-        :mosaic-pattern-options="mosaicPatternOptions"
-        :mosaic-allowed="mosaicAllowed"
-        :mosaic-extra-instrument-rotation="mosaicExtraInstrumentRotation"
-        :mosaic-max-num-pointings="mosaicMaxNumPointings"
-        :aladin-script-location="aladinScriptLocation"
-        :aladin-style-location="aladinStyleLocation"
-        :datetime-format="datetimeFormat"
         :form-config="formConfig"
-        :tooltip-config="tooltipConfig"
         @remove="removeRequest(idx)"
         @copy="addRequest(idx)"
         @request-updated="requestUpdated"
@@ -157,6 +142,7 @@
 <script>
 import _ from 'lodash';
 import moment from 'moment';
+import { inject } from '@vue/composition-api';
 
 import CustomModal from '@/components/RequestGroupComposition/CustomModal.vue';
 import Request from '@/components/RequestGroupComposition/Request.vue';
@@ -166,7 +152,7 @@ import CustomAlert from '@/components/RequestGroupComposition/CustomAlert.vue';
 import CustomField from '@/components/RequestGroupComposition/CustomField.vue';
 import CustomSelect from '@/components/RequestGroupComposition/CustomSelect.vue';
 import DataLoader from '@/components/Util/DataLoader.vue';
-import { generateDurationString, getFromObject, defaultTooltipConfig, defaultDatetimeFormat } from '@/util';
+import { generateDurationString, getFromObject, defaultDatetimeFormat } from '@/util';
 import requestExpansionWithModalConfirm from '@/composables/requestExpansionWithModalConfirm.js';
 
 export default {
@@ -224,52 +210,6 @@ export default {
         return {};
       }
     },
-    ditherPatternOptions: {
-      type: Array,
-      default: () => {
-        return [
-          { text: 'None', value: 'none' },
-          { text: 'Line', value: 'line' },
-          { text: 'Grid', value: 'grid' },
-          { text: 'Spiral', value: 'spiral' }
-        ];
-      }
-    },
-    ditheringAllowed: {
-      type: Function,
-      // eslint-disable-next-line no-unused-vars
-      default: (configuration, requestIndex, configurationIndex) => {
-        return true;
-      }
-    },
-    mosaicPatternOptions: {
-      type: Array,
-      default: () => {
-        return [
-          { text: 'None', value: 'none' },
-          { text: 'Line', value: 'line' },
-          { text: 'Grid', value: 'grid' }
-        ];
-      }
-    },
-    mosaicAllowed: {
-      type: Function,
-      // eslint-disable-next-line no-unused-vars
-      default: (request, requestIndex) => {
-        return true;
-      }
-    },
-    mosaicExtraInstrumentRotation: {
-      type: Function,
-      // eslint-disable-next-line no-unused-vars
-      default: configuration => {
-        return 0;
-      }
-    },
-    mosaicMaxNumPointings: {
-      type: Number,
-      default: 100
-    },
     observationTypeOptions: {
       type: Array,
       default: () => {
@@ -285,24 +225,6 @@ export default {
       default: () => {
         return {};
       }
-    },
-    datetimeFormat: {
-      type: String,
-      default: defaultDatetimeFormat
-    },
-    tooltipConfig: {
-      type: Object,
-      default: () => {
-        return defaultTooltipConfig;
-      }
-    },
-    aladinScriptLocation: {
-      type: String,
-      default: 'https://aladin.u-strasbg.fr/AladinLite/api/v2/latest/aladin.min.js'
-    },
-    aladinStyleLocation: {
-      type: String,
-      default: 'https://aladin.u-strasbg.fr/AladinLite/api/v2/latest/aladin.min.css'
     }
   },
   data: function() {
@@ -312,6 +234,7 @@ export default {
     };
   },
   setup: function() {
+    const datetimeFormat = inject('datetimeFormat', defaultDatetimeFormat);
     const {
       expansion,
       acceptExpansionForKeyOnObject,
@@ -326,7 +249,8 @@ export default {
       cancelExpansion,
       checkReadyToGenerateExpansion,
       generateExpansion,
-      getExpansionErrors
+      getExpansionErrors,
+      datetimeFormat
     };
   },
   computed: {

--- a/src/components/RequestGroupComposition/RequestGroupCompositionForm.vue
+++ b/src/components/RequestGroupComposition/RequestGroupCompositionForm.vue
@@ -6,18 +6,8 @@
         :duration-data="durationData"
         :request-group="requestGroup"
         :profile="profile"
-        :datetime-format="datetimeFormat"
-        :tooltip-config="tooltipConfig"
         :observation-portal-api-base-url="observationPortalApiBaseUrl"
         :observation-type-options="observationTypeOptions"
-        :dither-pattern-options="ditherPatternOptions"
-        :dithering-allowed="ditheringAllowed"
-        :mosaic-pattern-options="mosaicPatternOptions"
-        :mosaic-allowed="mosaicAllowed"
-        :mosaic-extra-instrument-rotation="mosaicExtraInstrumentRotation"
-        :mosaic-max-num-pointings="mosaicMaxNumPointings"
-        :aladin-script-location="aladinScriptLocation"
-        :aladin-style-location="aladinStyleLocation"
         :available-instruments="availableInstruments"
         :site-code-to-color="siteCodeToColor"
         :site-code-to-name="siteCodeToName"
@@ -76,11 +66,12 @@
 <script>
 import _ from 'lodash';
 import $ from 'jquery';
+import { provide } from '@vue/composition-api';
 
 import RequestGroup from '@/components/RequestGroupComposition/RequestGroup.vue';
 import RequestGroupSideNav from '@/components/RequestGroupComposition/RequestGroupSideNav.vue';
 import { confirmMixin } from '@/mixins/confirmMixins.js';
-import { generateDurationString, defaultTooltipConfig, defaultDatetimeFormat } from '@/util';
+import { generateDurationString, defaultTooltipConfig, defaultDatetimeFormat, defaultAladinScriptLocation, defaultAladinStyleLocation } from '@/util';
 
 export default {
   name: 'RequestGroupCompositionForm',
@@ -275,12 +266,12 @@ export default {
     // Location from which to load the aladin JavaScript https://aladin.u-strasbg.fr/AladinLite/doc/#embedding
     aladinScriptLocation: {
       type: String,
-      default: 'https://aladin.u-strasbg.fr/AladinLite/api/v2/latest/aladin.min.js'
+      default: defaultAladinScriptLocation
     },
     // Location from which to load the aladin CSS https://aladin.u-strasbg.fr/AladinLite/doc/#embedding
     aladinStyleLocation: {
       type: String,
-      default: 'https://aladin.u-strasbg.fr/AladinLite/api/v2/latest/aladin.min.css'
+      default: defaultAladinStyleLocation
     },
     // Object containing configuration for form panels and form fields. Top level fields are keys
     // referencing a panel, and map to an object that can contain a `panel` key to configure panel
@@ -335,6 +326,18 @@ export default {
       type: Number,
       default: -1
     }
+  },
+  setup: function(props) {
+    provide('mosaicMaxNumPointings', props.mosaicMaxNumPointings);
+    provide('mosaicExtraInstrumentRotation', props.mosaicExtraInstrumentRotation);
+    provide('mosaicPatternOptions', props.mosaicPatternOptions);
+    provide('mosaicAllowed', props.mosaicAllowed);
+    provide('ditherPatternOptions', props.ditherPatternOptions);
+    provide('ditheringAllowed', props.ditheringAllowed);
+    provide('aladinScriptLocation', props.aladinScriptLocation);
+    provide('aladinStyleLocation', props.aladinStyleLocation);
+    provide('tooltipConfig', props.tooltipConfig);
+    provide('datetimeFormat', props.datetimeFormat);
   },
   data: function() {
     return {

--- a/src/components/RequestGroupComposition/RequestGroupCompositionForm.vue
+++ b/src/components/RequestGroupComposition/RequestGroupCompositionForm.vue
@@ -71,7 +71,14 @@ import { provide } from '@vue/composition-api';
 import RequestGroup from '@/components/RequestGroupComposition/RequestGroup.vue';
 import RequestGroupSideNav from '@/components/RequestGroupComposition/RequestGroupSideNav.vue';
 import { confirmMixin } from '@/mixins/confirmMixins.js';
-import { generateDurationString, defaultTooltipConfig, defaultDatetimeFormat, defaultAladinScriptLocation, defaultAladinStyleLocation, mostRecentRequestManager } from '@/util';
+import {
+  generateDurationString,
+  defaultTooltipConfig,
+  defaultDatetimeFormat,
+  defaultAladinScriptLocation,
+  defaultAladinStyleLocation,
+  mostRecentRequestManager
+} from '@/util';
 
 export default {
   name: 'RequestGroupCompositionForm',

--- a/src/components/RequestGroupComposition/RequestGroupCompositionForm.vue
+++ b/src/components/RequestGroupComposition/RequestGroupCompositionForm.vue
@@ -15,6 +15,7 @@
         :mosaic-pattern-options="mosaicPatternOptions"
         :mosaic-allowed="mosaicAllowed"
         :mosaic-extra-instrument-rotation="mosaicExtraInstrumentRotation"
+        :mosaic-max-num-pointings="mosaicMaxNumPointings"
         :aladin-script-location="aladinScriptLocation"
         :aladin-style-location="aladinStyleLocation"
         :available-instruments="availableInstruments"
@@ -265,6 +266,11 @@ export default {
       default: configuration => {
         return 0;
       }
+    },
+    // Limit the number of pointings for performance and plotting purposes.
+    mosaicMaxNumPointings: {
+      type: Number,
+      default: 100
     },
     // Location from which to load the aladin JavaScript https://aladin.u-strasbg.fr/AladinLite/doc/#embedding
     aladinScriptLocation: {

--- a/src/components/RequestGroupComposition/SexagesimalCustomField.vue
+++ b/src/components/RequestGroupComposition/SexagesimalCustomField.vue
@@ -6,7 +6,6 @@
     :desc="desc"
     :hide="hide"
     :errors="errors"
-    :tooltip-config="tooltipConfig"
     :hide-when-collapsed="hideWhenCollapsed"
     @blur="update($event)"
   >
@@ -17,7 +16,7 @@
 </template>
 <script>
 import CustomField from '@/components/RequestGroupComposition/CustomField.vue';
-import { decimalRaToSexigesimal, decimalDecToSexigesimal, sexagesimalRaToDecimal, sexagesimalDecToDecimal, defaultTooltipConfig } from '@/util';
+import { decimalRaToSexigesimal, decimalDecToSexigesimal, sexagesimalRaToDecimal, sexagesimalDecToDecimal } from '@/util';
 
 export default {
   name: 'SexagesimalCustomField',
@@ -61,12 +60,6 @@ export default {
     desc: {
       type: String,
       default: ''
-    },
-    tooltipConfig: {
-      type: Object,
-      default: () => {
-        return defaultTooltipConfig;
-      }
     },
     errors: {
       validator: function(value) {

--- a/src/components/RequestGroupComposition/SexagesimalCustomField.vue
+++ b/src/components/RequestGroupComposition/SexagesimalCustomField.vue
@@ -9,7 +9,7 @@
     :tooltip-config="tooltipConfig"
     @blur="update($event)"
   >
-    <div v-if="value" slot="extra-help-text">
+    <div v-if="show && value" slot="extra-help-text">
       {{ helpText }}
     </div>
   </custom-field>

--- a/src/components/RequestGroupComposition/SexagesimalCustomField.vue
+++ b/src/components/RequestGroupComposition/SexagesimalCustomField.vue
@@ -7,6 +7,7 @@
     :hide="hide"
     :errors="errors"
     :tooltip-config="tooltipConfig"
+    :hide-when-collapsed="hideWhenCollapsed"
     @blur="update($event)"
   >
     <div v-if="show && value" slot="extra-help-text">
@@ -47,6 +48,10 @@ export default {
     },
     // Whether to collaspe field to just display the value.
     collapse: {
+      type: Boolean
+    },
+    // Hide this field when collapsed
+    hideWhenCollapsed: {
       type: Boolean
     },
     label: {

--- a/src/components/RequestGroupComposition/Target.vue
+++ b/src/components/RequestGroupComposition/Target.vue
@@ -8,7 +8,6 @@
     :can-remove="false"
     :show="show"
     :errors="errors"
-    :tooltip-config="tooltipConfig"
     @show="show = $event"
   >
     <custom-alert v-for="error in errors.non_field_errors" :key="error" alert-class="danger" :dismissible="false">
@@ -31,7 +30,6 @@
               :desc="getFromObject(formConfig, ['target', 'type', 'desc'], '')"
               :hide="getFromObject(formConfig, ['target', 'type', 'hide'], false)"
               :errors="errors.type"
-              :tooltip-config="tooltipConfig"
               :options="targetTypeOptions"
               @input="update"
             />
@@ -43,7 +41,6 @@
                 :label="getFromObject(formConfig, ['target', 'ra', 'label'], 'Right Ascension')"
                 :desc="getFromObject(formConfig, ['target', 'ra', 'desc'], '')"
                 :hide="getFromObject(formConfig, ['target', 'ra', 'hide'], false)"
-                :tooltip-config="tooltipConfig"
                 :collapse="!show"
                 :errors="errors.ra"
                 @input="update"
@@ -55,7 +52,6 @@
                 :label="getFromObject(formConfig, ['target', 'dec', 'label'], 'Declination')"
                 :desc="getFromObject(formConfig, ['target', 'dec', 'desc'], '')"
                 :hide="getFromObject(formConfig, ['target', 'dec', 'hide'], false)"
-                :tooltip-config="tooltipConfig"
                 :collapse="!show"
                 :errors="errors.dec"
                 @input="update"
@@ -66,7 +62,6 @@
                 :label="getFromObject(formConfig, ['target', 'proper_motion_ra', 'label'], 'Proper Motion RA')"
                 :desc="getFromObject(formConfig, ['target', 'proper_motion_ra', 'desc'], '')"
                 :hide="getFromObject(formConfig, ['target', 'proper_motion_ra', 'hide'], false)"
-                :tooltip-config="tooltipConfig"
                 :errors="errors.proper_motion_ra"
                 @input="update"
               />
@@ -76,7 +71,6 @@
                 :label="getFromObject(formConfig, ['target', 'proper_motion_dec', 'label'], 'Proper Motion Dec')"
                 :desc="getFromObject(formConfig, ['target', 'proper_motion_dec', 'desc'], '')"
                 :hide="getFromObject(formConfig, ['target', 'proper_motion_dec', 'hide'], false)"
-                :tooltip-config="tooltipConfig"
                 :errors="errors.proper_motion_dec"
                 @input="update"
               />
@@ -86,7 +80,6 @@
                 :label="getFromObject(formConfig, ['target', 'epoch', 'label'], 'Epoch')"
                 :desc="getFromObject(formConfig, ['target', 'epoch', 'desc'], '')"
                 :hide="getFromObject(formConfig, ['target', 'epoch', 'hide'], false)"
-                :tooltip-config="tooltipConfig"
                 :errors="errors.epoch"
                 @input="update"
               />
@@ -96,7 +89,6 @@
                 :label="getFromObject(formConfig, ['target', 'parallax', 'label'], 'Parallax')"
                 :desc="getFromObject(formConfig, ['target', 'parallax', 'desc'], '')"
                 :hide="getFromObject(formConfig, ['target', 'parallax', 'hide'], false)"
-                :tooltip-config="tooltipConfig"
                 :errors="errors.parallax"
                 @input="update"
               />
@@ -108,7 +100,6 @@
                 :label="getFromObject(formConfig, ['target', 'scheme', 'label'], 'Scheme')"
                 :desc="getFromObject(formConfig, ['target', 'scheme', 'desc'], '')"
                 :hide="getFromObject(formConfig, ['target', 'scheme', 'hide'], false)"
-                :tooltip-config="tooltipConfig"
                 :errors="errors.scheme"
                 :options="nonSiderealSchemeOptions"
                 @input="update"
@@ -119,7 +110,6 @@
                 :label="getFromObject(formConfig, ['target', 'epochofel', 'label'], 'Epoch of Elements')"
                 :desc="getFromObject(formConfig, ['target', 'epochofel', 'desc'], '')"
                 :hide="getFromObject(formConfig, ['target', 'epochofel', 'hide'], false)"
-                :tooltip-config="tooltipConfig"
                 :errors="errors.epochofel"
                 @input="update"
               />
@@ -129,7 +119,6 @@
                 :label="getFromObject(formConfig, ['target', 'orbinc', 'label'], 'Orbital Inclination')"
                 :desc="getFromObject(formConfig, ['target', 'orbinc', 'desc'], '')"
                 :hide="getFromObject(formConfig, ['target', 'orbinc', 'hide'], false)"
-                :tooltip-config="tooltipConfig"
                 :errors="errors.orbinc"
                 @input="update"
               />
@@ -139,7 +128,6 @@
                 :label="getFromObject(formConfig, ['target', 'longascnode', 'label'], 'Longitude of Ascending Node')"
                 :desc="getFromObject(formConfig, ['target', 'longascnode', 'desc'], '')"
                 :hide="getFromObject(formConfig, ['target', 'longascnode', 'hide'], false)"
-                :tooltip-config="tooltipConfig"
                 :errors="errors.longascnode"
                 @input="update"
               />
@@ -149,7 +137,6 @@
                 :label="getFromObject(formConfig, ['target', 'argofperih', 'label'], 'Argument of Perihelion')"
                 :desc="getFromObject(formConfig, ['target', 'argofperih', 'desc'], '')"
                 :hide="getFromObject(formConfig, ['target', 'argofperih', 'hide'], false)"
-                :tooltip-config="tooltipConfig"
                 :errors="errors.argofperih"
                 @input="update"
               />
@@ -159,7 +146,6 @@
                 :label="getFromObject(formConfig, ['target', 'eccentricity', 'label'], 'Eccentricity')"
                 :desc="getFromObject(formConfig, ['target', 'eccentricity', 'desc'], '')"
                 :hide="getFromObject(formConfig, ['target', 'eccentricity', 'hide'], false)"
-                :tooltip-config="tooltipConfig"
                 :errors="errors.eccentricity"
                 @input="update"
               />
@@ -171,7 +157,6 @@
                 :label="getFromObject(formConfig, ['target', 'meandist', 'label'], 'Semimajor Axis')"
                 :desc="getFromObject(formConfig, ['target', 'meandist', 'desc'], '')"
                 :hide="getFromObject(formConfig, ['target', 'meandist', 'hide'], false)"
-                :tooltip-config="tooltipConfig"
                 :errors="errors.meandist"
                 @input="update"
               />
@@ -181,7 +166,6 @@
                 :label="getFromObject(formConfig, ['target', 'meananom', 'label'], 'Mean Anomaly')"
                 :desc="getFromObject(formConfig, ['target', 'meananom', 'desc'], '')"
                 :hide="getFromObject(formConfig, ['target', 'meananom', 'hide'], false)"
-                :tooltip-config="tooltipConfig"
                 :errors="errors.meananom"
                 @input="update"
               />
@@ -193,7 +177,6 @@
                 :label="getFromObject(formConfig, ['target', 'dailymot', 'label'], 'Daily Motion')"
                 :desc="getFromObject(formConfig, ['target', 'dailymot', 'desc'], '')"
                 :hide="getFromObject(formConfig, ['target', 'dailymot', 'hide'], false)"
-                :tooltip-config="tooltipConfig"
                 :errors="errors.dailymot"
                 @input="update"
               />
@@ -205,7 +188,6 @@
                 :label="getFromObject(formConfig, ['target', 'perihdist', 'label'], 'Perihelion Distance')"
                 :desc="getFromObject(formConfig, ['target', 'perihdist', 'desc'], '')"
                 :hide="getFromObject(formConfig, ['target', 'perihdist', 'hide'], false)"
-                :tooltip-config="tooltipConfig"
                 :errors="errors.perihdist"
                 @input="update"
               />
@@ -215,7 +197,6 @@
                 :label="getFromObject(formConfig, ['target', 'epochofperih', 'label'], 'Epoch of Perihelion')"
                 :desc="getFromObject(formConfig, ['target', 'epochofperih', 'desc'], '')"
                 :hide="getFromObject(formConfig, ['target', 'epochofperih', 'hide'], false)"
-                :tooltip-config="tooltipConfig"
                 :errors="errors.epochofperih"
                 @input="update"
               />
@@ -235,7 +216,7 @@ import CustomField from '@/components/RequestGroupComposition/CustomField.vue';
 import SexagesimalCustomField from '@/components/RequestGroupComposition/SexagesimalCustomField.vue';
 import CustomSelect from '@/components/RequestGroupComposition/CustomSelect.vue';
 import { collapseMixin } from '@/mixins/collapseMixins.js';
-import { getFromObject, defaultTooltipConfig } from '@/util';
+import { getFromObject } from '@/util';
 
 export default {
   name: 'Target',
@@ -268,12 +249,6 @@ export default {
     },
     parentShow: {
       type: Boolean
-    },
-    tooltipConfig: {
-      type: Object,
-      default: () => {
-        return defaultTooltipConfig;
-      }
     },
     formConfig: {
       type: Object,

--- a/src/components/RequestGroupComposition/Target.vue
+++ b/src/components/RequestGroupComposition/Target.vue
@@ -298,7 +298,7 @@ export default {
     delete siderealTargetParams['name'];
     delete siderealTargetParams['type'];
     return {
-      show: true,
+      show: this.parentShow,
       nonSiderealTargetParams: nonSiderealTargetParams,
       siderealTargetParams: siderealTargetParams,
       targetTypeOptions: [

--- a/src/components/RequestGroupComposition/Window.vue
+++ b/src/components/RequestGroupComposition/Window.vue
@@ -9,7 +9,6 @@
     :errors="errors"
     :show="show"
     :index="index"
-    :tooltip-config="tooltipConfig"
     @remove="$emit('remove')"
     @copy="$emit('copy')"
     @show="show = $event"
@@ -43,8 +42,6 @@
               :label="getFromObject(formConfig, ['window', 'start', 'label'], 'Start')"
               :desc="getFromObject(formConfig, ['window', 'start', 'desc'], '')"
               :hide="getFromObject(formConfig, ['window', 'start', 'hide'], false)"
-              :datetime-format="datetimeFormat"
-              :tooltip-config="tooltipConfig"
               :errors="errors.start"
               @input="update"
             />
@@ -54,8 +51,6 @@
               :label="getFromObject(formConfig, ['window', 'end', 'label'], 'End')"
               :desc="getFromObject(formConfig, ['window', 'end', 'desc'], '')"
               :hide="getFromObject(formConfig, ['window', 'end', 'hide'], false)"
-              :datetime-format="datetimeFormat"
-              :tooltip-config="tooltipConfig"
               :errors="errors.end"
               @input="update"
             />
@@ -66,7 +61,6 @@
               :desc="getFromObject(formConfig, ['window', 'cadence', 'desc'], '')"
               :hide="getFromObject(formConfig, ['window', 'cadence', 'hide'], false)"
               hide-when-collapsed
-              :tooltip-config="tooltipConfig"
               :options="[
                 { text: 'None', value: 'none' },
                 { text: 'Simple Period', value: 'simple' }
@@ -79,7 +73,6 @@
               :label="getFromObject(formConfig, ['window', 'period', 'label'], 'Period')"
               :desc="getFromObject(formConfig, ['window', 'period', 'desc'], '')"
               :hide="getFromObject(formConfig, ['window', 'period', 'hide'], false)"
-              :tooltip-config="tooltipConfig"
               :errors="errors.period"
               @input="update"
             />
@@ -90,7 +83,6 @@
               :label="getFromObject(formConfig, ['window', 'jitter', 'label'], 'Jitter')"
               :desc="getFromObject(formConfig, ['window', 'jitter', 'desc'], '')"
               :hide="getFromObject(formConfig, ['window', 'jitter', 'hide'], false)"
-              :tooltip-config="tooltipConfig"
               :errors="errors.jitter"
               @input="update"
             />
@@ -123,7 +115,7 @@ import CustomSelect from '@/components/RequestGroupComposition/CustomSelect.vue'
 import CustomDatetime from '@/components/RequestGroupComposition/CustomDatetime.vue';
 import AirmassPlot from '@/components/Plots/AirmassPlot.vue';
 
-import { extractTopLevelErrors, getFromObject, defaultTooltipConfig, defaultDatetimeFormat } from '@/util.js';
+import { extractTopLevelErrors, getFromObject } from '@/util.js';
 import { collapseMixin } from '@/mixins/collapseMixins.js';
 
 export default {
@@ -173,16 +165,6 @@ export default {
     },
     parentShow: {
       type: Boolean
-    },
-    datetimeFormat: {
-      type: String,
-      default: defaultDatetimeFormat
-    },
-    tooltipConfig: {
-      type: Object,
-      default: () => {
-        return defaultTooltipConfig;
-      }
     },
     observationType: {
       type: String,

--- a/src/components/RequestGroupComposition/Window.vue
+++ b/src/components/RequestGroupComposition/Window.vue
@@ -65,6 +65,7 @@
               :label="getFromObject(formConfig, ['window', 'cadence', 'label'], 'Cadence')"
               :desc="getFromObject(formConfig, ['window', 'cadence', 'desc'], '')"
               :hide="getFromObject(formConfig, ['window', 'cadence', 'hide'], false)"
+              hide-when-collapsed
               :tooltip-config="tooltipConfig"
               :options="[
                 { text: 'None', value: 'none' },

--- a/src/composables/requestExpansionWithModalConfirm.js
+++ b/src/composables/requestExpansionWithModalConfirm.js
@@ -87,7 +87,7 @@ export default function requestExpansionWithModalConfirm() {
     return errors;
   };
 
-  const acceptExpansionForKeyOnObject = (obj, key) => {
+  const acceptExpansionForKeyOnObject = (obj, key, onDone) => {
     // Accept the generated expansion by setting the `key` of the provided `obj` to the expanded data.
     // Updating the `key` of `obj` means that the `obj` itself that is passed is updated (pass-by-reference),
     // so that if it was a reactive variable inside a component, the component will re-render.
@@ -98,6 +98,9 @@ export default function requestExpansionWithModalConfirm() {
     Vue.nextTick(() => {
       obj[key] = expansion.value.expanded;
       expansion.value.expanded = [];
+      if (onDone) {
+        onDone();
+      }
       return obj;
     });
   };

--- a/src/composables/requestExpansionWithModalConfirm.js
+++ b/src/composables/requestExpansionWithModalConfirm.js
@@ -15,7 +15,8 @@ export default function requestExpansionWithModalConfirm() {
       loaded: false,
       errorResponse: {}
     },
-    expanded: []
+    expanded: [],
+    expansionExtraInfo: {}
   });
 
   const checkReadyToGenerateExpansion = (errorMessage, errorCheck) => {
@@ -31,11 +32,26 @@ export default function requestExpansionWithModalConfirm() {
     }
   };
 
-  const generateExpansion = (url, parameters, getExpandedFromResponse) => {
+  const generateExpansion = (
+    url,
+    parameters,
+    getExpandedFromResponse,
+    {
+      saveExtraInfo = false,
+      getExtraInfoFromResponse = response => {
+        return response.extra_params || {};
+      }
+    } = {}
+  ) => {
     // Generate the expansion
     // `url` is the endpoint that generates the expansion
     // `parameters` is an object containing the POST data to sent along with the HTTP request
-    // `getExpandedFromResponse` is a function that returns the section of the response that is the expanded section
+    // `getExpandedFromResponse` is a function that returns the section of the response that is the expanded section. Expected
+    //      to return an array.
+    // `saveExtraInfo` is a boolean indicating whether to save extra information about the request.
+    // `getExtraInfoFromResponse` is a function that returns the section of the response that contains extra information about
+    //      the expansion if `saveExtraInfo` is `true`. Expected to return an object. By default it saves the `extra_params` field
+    //      of the response.
     expansion.value.showModal = true;
     expansion.value.status.loaded = false;
     expansion.value.status.error = false;
@@ -53,6 +69,9 @@ export default function requestExpansionWithModalConfirm() {
           expansion.value.status.notFound = true;
         } else {
           expansion.value.expanded = expanded;
+          if (saveExtraInfo) {
+            expansion.value.expansionExtraInfo = getExtraInfoFromResponse(response);
+          }
         }
       })
       .fail(response => {
@@ -68,6 +87,7 @@ export default function requestExpansionWithModalConfirm() {
     // Clear out the expansion.
     expansion.value.showModal = false;
     expansion.value.expanded = [];
+    expansion.value.expansionExtraInfo = {};
   };
 
   const getExpansionErrors = () => {
@@ -87,20 +107,23 @@ export default function requestExpansionWithModalConfirm() {
     return errors;
   };
 
-  const acceptExpansionForKeyOnObject = (obj, key, onDone) => {
+  const acceptExpansionForKeyOnObject = (obj, key, { addExtraInfo = false, onDone = () => {}, extraInfoKey = 'extra_params' } = {}) => {
     // Accept the generated expansion by setting the `key` of the provided `obj` to the expanded data.
     // Updating the `key` of `obj` means that the `obj` itself that is passed is updated (pass-by-reference),
-    // so that if it was a reactive variable inside a component, the component will re-render.
+    // so that if it was a reactive variable inside a component, the component will re-render. To add the
+    // saved extra expansion information onto the object, set `addExtraInfo` to `true`.
     expansion.value.showModal = false;
     // Clear out expanded section before setting it again to allow any existing associated components
     // to re-render so that the mounted hook is entered.
     obj[key] = [];
     Vue.nextTick(() => {
       obj[key] = expansion.value.expanded;
-      expansion.value.expanded = [];
-      if (onDone) {
-        onDone();
+      if (addExtraInfo) {
+        obj[extraInfoKey] = expansion.value.expansionExtraInfo;
       }
+      expansion.value.expanded = [];
+      expansion.value.expansionExtraInfo = {};
+      onDone();
       return obj;
     });
   };

--- a/src/util.js
+++ b/src/util.js
@@ -11,6 +11,9 @@ const defaultTooltipConfig = {
 
 const defaultDatetimeFormat = 'YYYY-MM-DD HH:mm:ss';
 
+const defaultAladinScriptLocation = 'https://aladin.u-strasbg.fr/AladinLite/api/v2/latest/aladin.min.js';
+const defaultAladinStyleLocation = 'https://aladin.u-strasbg.fr/AladinLite/api/v2/latest/aladin.min.css';
+
 function zPadFloat(num) {
   return num.toLocaleString(undefined, { minimumIntegerDigits: 2, maximumFractionDigits: 4 });
 }
@@ -273,6 +276,8 @@ export {
   cosineDeclinationTerm,
   decimalDecToSexigesimal,
   decimalRaToSexigesimal,
+  defaultAladinScriptLocation,
+  defaultAladinStyleLocation,
   defaultDatetimeFormat,
   defaultTooltipConfig,
   extractTopLevelErrors,


### PR DESCRIPTION
In this PR:
- Automatically collapse all but the first configuration when loading in a mosaic.
- Update custom fields to use [`v-if` instead of `v-show`](https://vuejs.org/v2/guide/conditional.html#v-if-vs-v-show) to cut down on initial rendering times when the fields start out collapsed. This means that the input fields will only be rendered if the the show value is true, unlike when using v-show, which renders everything and only toggles CSS to display/ hide the input fields. The cost to toggle the collapse state of a panel is greater, but it doesn't make the page feel any more sluggish to me, especially when toggling smaller portions of the form which is more likely. Toggling an entire massive request will take a while, but that seems like something that doesn't happen all that often, and at least initial render times are faster when pre-collapsed. This cut the time to load in a large mosaic in half.
- Update collapsed fields to use red text so that even when the panel is collapsed, you can see where there are errors.
- Added a `hideWhenCollapsed` field to the custom input fields to be able to hide individual fields when the form is collapsed.  This attribute is being set on things like the dither parameter fields, which should not be displayed when collapsed.
- Set a configurable maximum number of mosaic pointings that a user can expand.