### PR TITLE
Feature/constraints form slot

### DIFF
--- a/src/components/RequestGroupComposition/Configuration.vue
+++ b/src/components/RequestGroupComposition/Configuration.vue
@@ -364,7 +364,7 @@
         <slot name="target-name-field" :data="data.data" :update="data.update"></slot>
       </template>
     </target>
-    <constraints
+    <constraints-panel
       :configuration-index="index"
       :request-index="requestIndex"
       :constraints="configuration.constraints"
@@ -372,12 +372,15 @@
       :form-config="formConfig"
       :tooltip-config="tooltipConfig"
       :errors="getFromObject(errors, 'constraints', {})"
-      @constraintsupdate="constraintsUpdated"
+      @constraints-update="constraintsUpdated"
     >
       <template #constraints-help="data">
         <slot name="constraints-help" :data="data.data"></slot>
       </template>
-    </constraints>
+      <template #constraints-form="data">
+        <slot name="constraints-form" :data="data.data" :update="data.update"></slot>
+      </template>
+    </constraints-panel>
   </form-panel>
 </template>
 <script>
@@ -389,7 +392,7 @@ import CustomField from '@/components/RequestGroupComposition/CustomField.vue';
 import CustomModal from '@/components/RequestGroupComposition/CustomModal.vue';
 import CustomSelect from '@/components/RequestGroupComposition/CustomSelect.vue';
 import InstrumentConfigPanel from '@/components/RequestGroupComposition/InstrumentConfigPanel.vue';
-import Constraints from '@/components/RequestGroupComposition/Constraints.vue';
+import ConstraintsPanel from '@/components/RequestGroupComposition/ConstraintsPanel.vue';
 import Target from '@/components/RequestGroupComposition/Target.vue';
 import DitherPatternPlot from '@/components/Plots/DitherPatternPlot.vue';
 import DataLoader from '@/components/Util/DataLoader.vue';
@@ -408,7 +411,7 @@ export default {
     CustomAlert,
     InstrumentConfigPanel,
     DitherPatternPlot,
-    Constraints,
+    ConstraintsPanel,
     Target
   },
   filters: {

--- a/src/components/RequestGroupComposition/ConstraintsForm.vue
+++ b/src/components/RequestGroupComposition/ConstraintsForm.vue
@@ -18,6 +18,33 @@
       :errors="errors.min_lunar_distance"
       @input="update"
     />
+    <custom-field
+      v-model="constraints.max_lunar_phase"
+      field="max_lunar_phase"
+      :label="getFromObject(formConfig, ['constraints', 'max_lunar_phase', 'label'], 'Maximum Lunar Phase')"
+      :desc="getFromObject(formConfig, ['constraints', 'max_lunar_phase', 'desc'], '')"
+      :hide="getFromObject(formConfig, ['constraints', 'max_lunar_phase', 'hide'], false)"
+      :errors="errors.max_lunar_phase"
+      @input="update"
+    />
+    <custom-field
+      v-model="constraints.max_seeing"
+      field="max_seeing"
+      :label="getFromObject(formConfig, ['constraints', 'max_seeing', 'label'], 'Maximum Seeing')"
+      :desc="getFromObject(formConfig, ['constraints', 'max_seeing', 'desc'], '')"
+      :hide="getFromObject(formConfig, ['constraints', 'max_seeing', 'hide'], false)"
+      :errors="errors.max_seeing"
+      @input="update"
+    />
+    <custom-field
+      v-model="constraints.min_transparency"
+      field="min_transparency"
+      :label="getFromObject(formConfig, ['constraints', 'min_transparency', 'label'], 'Minimum Transparency')"
+      :desc="getFromObject(formConfig, ['constraints', 'min_transparency', 'desc'], '')"
+      :hide="getFromObject(formConfig, ['constraints', 'min_transparency', 'hide'], false)"
+      :errors="errors.min_transparency"
+      @input="update"
+    />
   </b-form>
 </template>
 <script>

--- a/src/components/RequestGroupComposition/ConstraintsForm.vue
+++ b/src/components/RequestGroupComposition/ConstraintsForm.vue
@@ -1,0 +1,66 @@
+<template>
+  <b-form :id="id">
+    <custom-field
+      v-model="constraints.max_airmass"
+      field="max_airmass"
+      :label="getFromObject(formConfig, ['constraints', 'max_airmass', 'label'], 'Maximum Airmass')"
+      :desc="getFromObject(formConfig, ['constraints', 'max_airmass', 'desc'], '')"
+      :hide="getFromObject(formConfig, ['constraints', 'max_airmass', 'hide'], false)"
+      :errors="errors.max_airmass"
+      @input="update"
+    />
+    <custom-field
+      v-model="constraints.min_lunar_distance"
+      field="min_lunar_distance"
+      :label="getFromObject(formConfig, ['constraints', 'min_lunar_distance', 'label'], 'Minimum Lunar Separation')"
+      :desc="getFromObject(formConfig, ['constraints', 'min_lunar_distance', 'desc'], '')"
+      :hide="getFromObject(formConfig, ['constraints', 'min_lunar_distance', 'hide'], false)"
+      :errors="errors.min_lunar_distance"
+      @input="update"
+    />
+  </b-form>
+</template>
+<script>
+import CustomField from '@/components/RequestGroupComposition/CustomField.vue';
+import baseConstraints from '@/composables/baseConstraints.js';
+import { getFromObject } from '@/util';
+
+export default {
+  name: 'Constraints',
+  components: {
+    CustomField
+  },
+  props: {
+    id: {
+      type: String,
+      required: true
+    },
+    constraints: {
+      type: Object,
+      required: true
+    },
+    errors: {
+      type: Object,
+      required: true
+    },
+    show: {
+      type: Boolean
+    },
+    formConfig: {
+      type: Object,
+      default: () => {
+        return {};
+      }
+    }
+  },
+  setup: function(props, context) {
+    const { update } = baseConstraints(context);
+    return { update };
+  },
+  methods: {
+    getFromObject(obj, path, defaultValue) {
+      return getFromObject(obj, path, defaultValue);
+    }
+  }
+};
+</script>

--- a/src/components/RequestGroupComposition/ConstraintsPanel.vue
+++ b/src/components/RequestGroupComposition/ConstraintsPanel.vue
@@ -8,7 +8,6 @@
     :can-remove="false"
     :errors="errors"
     :show="show"
-    :tooltip-config="tooltipConfig"
     @show="show = $event"
   >
     <custom-alert v-for="error in errors.non_field_errors" :key="error" alert-class="danger" :dismissible="false">
@@ -20,28 +19,16 @@
           <slot name="constraints-help" :data="{ constraints: constraints, position: position }"></slot>
         </b-col>
         <b-col :md="show ? 6 : 12">
-          <b-form>
-            <custom-field
-              v-model="constraints.max_airmass"
-              field="max_airmass"
-              :label="getFromObject(formConfig, ['constraints', 'max_airmass', 'label'], 'Maximum Airmass')"
-              :desc="getFromObject(formConfig, ['constraints', 'max_airmass', 'desc'], '')"
-              :hide="getFromObject(formConfig, ['constraints', 'max_airmass', 'hide'], false)"
-              :tooltip-config="tooltipConfig"
-              :errors="errors.max_airmass"
-              @input="update"
+          <slot name="constraints-form" :update="update" :data="{ constraints: constraints, errors: errors, show: show, position: position }">
+            <constraints-form
+              :id="'constraints-form' + position.requestIndex + position.configurationIndex"
+              :show="show"
+              :constraints="constraints"
+              :errors="errors"
+              :form-config="formConfig"
+              @constraints-update="update"
             />
-            <custom-field
-              v-model="constraints.min_lunar_distance"
-              field="min_lunar_distance"
-              :label="getFromObject(formConfig, ['constraints', 'min_lunar_distance', 'label'], 'Minimum Lunar Separation')"
-              :desc="getFromObject(formConfig, ['constraints', 'min_lunar_distance', 'desc'], '')"
-              :hide="getFromObject(formConfig, ['constraints', 'min_lunar_distance', 'hide'], false)"
-              :tooltip-config="tooltipConfig"
-              :errors="errors.min_lunar_distance"
-              @input="update"
-            />
-          </b-form>
+          </slot>
         </b-col>
       </b-row>
     </b-container>
@@ -49,18 +36,16 @@
 </template>
 <script>
 import FormPanel from '@/components/RequestGroupComposition/FormPanel.vue';
-import CustomAlert from '@/components/RequestGroupComposition/CustomAlert.vue';
-import CustomField from '@/components/RequestGroupComposition/CustomField.vue';
+import ConstraintsForm from '@/components/RequestGroupComposition/ConstraintsForm.vue';
 
 import { collapseMixin } from '@/mixins/collapseMixins.js';
-import { getFromObject, defaultTooltipConfig } from '@/util';
+import { getFromObject } from '@/util';
 
 export default {
   name: 'Constraints',
   components: {
-    CustomField,
     FormPanel,
-    CustomAlert
+    ConstraintsForm
   },
   mixins: [collapseMixin],
   props: {
@@ -80,12 +65,6 @@ export default {
       type: Object,
       required: true
     },
-    tooltipConfig: {
-      type: Object,
-      default: () => {
-        return defaultTooltipConfig;
-      }
-    },
     parentShow: {
       type: Boolean
     },
@@ -98,7 +77,7 @@ export default {
   },
   data: function() {
     return {
-      show: true,
+      show: this.parentShow,
       position: {
         requestIndex: this.requestIndex,
         configurationIndex: this.configurationIndex
@@ -110,7 +89,7 @@ export default {
       return getFromObject(obj, path, defaultValue);
     },
     update: function() {
-      this.$emit('constraintsupdate');
+      this.$emit('constraints-update');
     }
   }
 };

--- a/src/components/RequestGroupComposition/Request.vue
+++ b/src/components/RequestGroupComposition/Request.vue
@@ -263,6 +263,9 @@
       <template #constraints-help="data">
         <slot name="constraints-help" :data="data.data"></slot>
       </template>
+      <template #constraints-form="data">
+        <slot name="constraints-form" :data="data.data" :update="data.update"></slot>
+      </template>
     </configuration>
     <window
       v-for="(window, idx) in request.windows"

--- a/src/components/RequestGroupComposition/RequestGroup.vue
+++ b/src/components/RequestGroupComposition/RequestGroup.vue
@@ -146,6 +146,9 @@
         <template #constraints-help="data">
           <slot name="constraints-help" :data="data.data"></slot>
         </template>
+        <template #constraints-form="data">
+          <slot name="constraints-form" :data="data.data" :update="data.update"></slot>
+        </template>
         <template #window-help="data">
           <slot name="window-help" :data="data.data"></slot>
         </template>

--- a/src/components/RequestGroupComposition/RequestGroupCompositionForm.vue
+++ b/src/components/RequestGroupComposition/RequestGroupCompositionForm.vue
@@ -163,7 +163,10 @@ export default {
                   },
                   constraints: {
                     max_airmass: 1.6,
-                    min_lunar_distance: 30.0
+                    min_lunar_distance: 30.0,
+                    max_lunar_phase: null,
+                    max_seeing: null,
+                    min_transparency: null
                   }
                 }
               ],

--- a/src/components/RequestGroupComposition/RequestGroupCompositionForm.vue
+++ b/src/components/RequestGroupComposition/RequestGroupCompositionForm.vue
@@ -49,6 +49,9 @@
         <template #constraints-help="data">
           <slot name="constraints-help" :data="data.data"></slot>
         </template>
+        <template #constraints-form="data">
+          <slot name="constraints-form" :data="data.data" :update="data.update"></slot>
+        </template>
         <template #window-help="data">
           <slot name="window-help" :data="data.data"></slot>
         </template>

--- a/src/composables/baseConstraints.js
+++ b/src/composables/baseConstraints.js
@@ -1,0 +1,7 @@
+export default function baseConstraints(context) {
+  const update = () => {
+    context.emit('constraints-update');
+  };
+
+  return { update };
+}

--- a/src/composables/index.js
+++ b/src/composables/index.js
@@ -1,4 +1,5 @@
 import baseInstrumentConfig from './baseInstrumentConfig.js';
+import baseConstraints from './baseConstraints.js';
 import requestExpansionWithModalConfirm from './requestExpansionWithModalConfirm.js';
 
-export { baseInstrumentConfig, requestExpansionWithModalConfirm };
+export { baseConstraints, baseInstrumentConfig, requestExpansionWithModalConfirm };


### PR DESCRIPTION
I received a request to be able to display the `max_lunar_phase` constraint on the requestgroup composition form. Previously we had only had input fields for `max_airmass` and `min_lunar_distance` on the form, since those are the only constraints that are fully plumbed into LCO's OCS, but this isn't necessarily the case for others.

This PR add fields for all the constraints that had previously been left off, which can be hidden using the `formConfig` prop. I also updated the constraints panel to allow users to entirely write their own constraints form using the `constraints-form` slot, similar to how users can write their own instrument config form using the `instrument-config-form` slot. So now there are two ways to add more constraints fields, and also just allow users more flexibility to specify what they want to display in that panel.

I ultimately want to provide slots to override the forms of all the different panels, not just the instrument config and constraints panels, but I'm adding them in as needed for now.