### PR TITLE
Set the default configuration type value when switching instruments i…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ocs-component-lib",
-  "version": "0.12.0",
+  "version": "0.12.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ocs-component-lib",
-  "version": "0.12.0",
+  "version": "0.12.2",
   "private": false,
   "description": "Component library for an astronomical observatory control system frontend",
   "scripts": {

--- a/src/components/RequestGroupComposition/Configuration.vue
+++ b/src/components/RequestGroupComposition/Configuration.vue
@@ -709,8 +709,8 @@ export default {
       let defaultConfigurationType = _.get(this.availableInstruments, [this.configuration.instrument_type, 'default_configuration_type'], '');
       let options = this.configurationTypeOptions;
       let defaultIndex = 0;
-      options.forEach(function (configurationType, i){
-        if (configurationType.value === defaultConfigurationType){
+      options.forEach(function(configurationType, i) {
+        if (configurationType.value === defaultConfigurationType) {
           defaultIndex = i;
         }
       });

--- a/src/components/RequestGroupComposition/Configuration.vue
+++ b/src/components/RequestGroupComposition/Configuration.vue
@@ -654,7 +654,7 @@ export default {
     },
     configurationTypeOptions: function(options) {
       if (this.configuration.type === '') {
-        this.configuration.type = _.get(options, [0, 'value'], '');
+        this.configuration.type = _.get(options, [this.defaultConfigurationTypeIndex(), 'value'], '');
       }
     },
     guideModeOptions: function(options) {
@@ -705,13 +705,24 @@ export default {
     getFromObject(obj, path, defaultValue) {
       return getFromObject(obj, path, defaultValue);
     },
+    defaultConfigurationTypeIndex: function() {
+      let defaultConfigurationType = _.get(this.availableInstruments, [this.configuration.instrument_type, 'default_configuration_type'], '');
+      let options = this.configurationTypeOptions;
+      let defaultIndex = 0;
+      options.forEach(function (configurationType, i){
+        if (configurationType.value === defaultConfigurationType){
+          defaultIndex = i;
+        }
+      });
+      return defaultIndex;
+    },
     onInstrumentCategoryChange: function() {
       this.configuration.instrument_type = _.get(this.availableInstrumentOptions, [0, 'value'], '');
-      this.configuration.type = _.get(this.configurationTypeOptions, [0, 'value'], '');
+      this.configuration.type = _.get(this.configurationTypeOptions, [this.defaultConfigurationTypeIndex(), 'value'], '');
       this.update();
     },
     onInstrumentTypeChange: function() {
-      this.configuration.type = _.get(this.configurationTypeOptions, [0, 'value'], '');
+      this.configuration.type = _.get(this.configurationTypeOptions, [this.defaultConfigurationTypeIndex(), 'value'], '');
       this.update();
     },
     getConfigurationTypeToInstrumentCategoriesArray: function() {


### PR DESCRIPTION
…n the composition page. This uses the new default_configuration_type added to the instrument info in the [observation portal PR](https://github.com/observatorycontrolsystem/observation-portal/pull/224)