### PR TITLE
Add new slot for extra fields at the bottom of the target form

### DIFF
--- a/src/components/RequestGroupComposition/Configuration.vue
+++ b/src/components/RequestGroupComposition/Configuration.vue
@@ -351,6 +351,9 @@
       <template #target-name-field="data">
         <slot name="target-name-field" :data="data.data" :update="data.update"></slot>
       </template>
+      <template #target-fields-footer="data">
+        <slot name="target-fields-footer" :data="data.data" :update="data.update"></slot>
+      </template>
     </target>
     <constraints-panel
       :configuration-index="index"

--- a/src/components/RequestGroupComposition/Request.vue
+++ b/src/components/RequestGroupComposition/Request.vue
@@ -263,6 +263,9 @@
       <template #target-name-field="data">
         <slot name="target-name-field" :data="data.data" :update="data.update"></slot>
       </template>
+      <template #target-fields-footer="data">
+        <slot name="target-fields-footer" :data="data.data" :update="data.update"></slot>
+      </template>
       <template #constraints-help="data">
         <slot name="constraints-help" :data="data.data"></slot>
       </template>

--- a/src/components/RequestGroupComposition/RequestGroup.vue
+++ b/src/components/RequestGroupComposition/RequestGroup.vue
@@ -129,6 +129,9 @@
         <template #target-name-field="data">
           <slot name="target-name-field" :data="data.data" :update="data.update"></slot>
         </template>
+        <template #target-fields-footer="data">
+          <slot name="target-fields-footer" :data="data.data" :update="data.update"></slot>
+        </template>
         <template #constraints-help="data">
           <slot name="constraints-help" :data="data.data"></slot>
         </template>

--- a/src/components/RequestGroupComposition/RequestGroupCompositionForm.vue
+++ b/src/components/RequestGroupComposition/RequestGroupCompositionForm.vue
@@ -37,6 +37,9 @@
         <template #target-name-field="data">
           <slot name="target-name-field" :data="data.data" :update="data.update"></slot>
         </template>
+        <template #target-fields-footer="data">
+          <slot name="target-fields-footer" :data="data.data" :update="data.update"></slot>
+        </template>
         <template #constraints-help="data">
           <slot name="constraints-help" :data="data.data"></slot>
         </template>
@@ -158,7 +161,8 @@ export default {
                     proper_motion_ra: 0.0,
                     proper_motion_dec: 0.0,
                     epoch: 2000,
-                    parallax: 0
+                    parallax: 0,
+                    extra_params: {}
                   },
                   constraints: {
                     max_airmass: 1.6,

--- a/src/components/RequestGroupComposition/Target.vue
+++ b/src/components/RequestGroupComposition/Target.vue
@@ -201,6 +201,8 @@
                 @input="update"
               />
             </span>
+            <slot name="target-fields-footer" :update="update" :data="{ target: target, errors: errors.name, position: position }">
+            </slot>
           </b-form>
         </b-col>
       </b-row>
@@ -267,7 +269,8 @@ export default {
       meandist: null,
       meananom: null,
       perihdist: null,
-      epochofperih: null
+      epochofperih: null,
+      extra_params: {}
     };
     let siderealTargetParams = _.cloneDeep(this.target);
     delete siderealTargetParams['name'];

--- a/src/components/RequestGroupComposition/Target.vue
+++ b/src/components/RequestGroupComposition/Target.vue
@@ -201,8 +201,7 @@
                 @input="update"
               />
             </span>
-            <slot name="target-fields-footer" :update="update" :data="{ target: target, errors: errors.name, position: position }">
-            </slot>
+            <slot name="target-fields-footer" :update="update" :data="{ target: target, errors: errors.name, position: position }"></slot>
           </b-form>
         </b-col>
       </b-row>


### PR DESCRIPTION
Adding a slot at the end of the target form for extra fields to be inserted, so I can insert the `fractional_ephemeris_rate` `extra_params` field in our compose page. I hate how much code duplication is needed propagating the slot up the object hierarchy... hopefully vue 3.0 has a better method for this type of thing that we should switch to but I haven't invested enough time to figure it out yet.