### PR TITLE
Feature/seeing constraint

### DIFF
--- a/src/components/RequestGroupComposition/Configuration.vue
+++ b/src/components/RequestGroupComposition/Configuration.vue
@@ -361,6 +361,7 @@
       :constraints="configuration.constraints"
       :parent-show="show"
       :form-config="formConfig"
+      :available-seeing-options="availableSeeingOptions"
       :errors="getFromObject(errors, 'constraints', {})"
       @constraints-update="constraintsUpdated"
     >
@@ -461,7 +462,13 @@ export default {
       default: () => {
         return {};
       }
-    }
+    },
+    availableSeeingOptions: {
+      type: Array,
+      default: () => {
+        return [];
+      }
+    },
   },
   data: function() {
     return {

--- a/src/components/RequestGroupComposition/Configuration.vue
+++ b/src/components/RequestGroupComposition/Configuration.vue
@@ -468,7 +468,7 @@ export default {
       default: () => {
         return [];
       }
-    },
+    }
   },
   data: function() {
     return {

--- a/src/components/RequestGroupComposition/ConstraintsForm.vue
+++ b/src/components/RequestGroupComposition/ConstraintsForm.vue
@@ -27,12 +27,13 @@
       :errors="errors.max_lunar_phase"
       @input="update"
     />
-    <custom-field
+    <custom-select
       v-model="constraints.max_seeing"
       field="max_seeing"
       :label="getFromObject(formConfig, ['constraints', 'max_seeing', 'label'], 'Maximum Seeing')"
       :desc="getFromObject(formConfig, ['constraints', 'max_seeing', 'desc'], '')"
       :hide="getFromObject(formConfig, ['constraints', 'max_seeing', 'hide'], false)"
+      :options="availableSeeingOptions"
       :errors="errors.max_seeing"
       @input="update"
     />
@@ -49,13 +50,15 @@
 </template>
 <script>
 import CustomField from '@/components/RequestGroupComposition/CustomField.vue';
+import CustomSelect from '@/components/RequestGroupComposition/CustomSelect.vue';
 import baseConstraints from '@/composables/baseConstraints.js';
 import { getFromObject } from '@/util';
 
 export default {
   name: 'Constraints',
   components: {
-    CustomField
+    CustomField,
+    CustomSelect
   },
   props: {
     id: {
@@ -72,6 +75,12 @@ export default {
     },
     show: {
       type: Boolean
+    },
+    availableSeeingOptions: {
+      type: Array,
+      default: () => {
+        return [];
+      }
     },
     formConfig: {
       type: Object,

--- a/src/components/RequestGroupComposition/ConstraintsPanel.vue
+++ b/src/components/RequestGroupComposition/ConstraintsPanel.vue
@@ -26,6 +26,7 @@
               :constraints="constraints"
               :errors="errors"
               :form-config="formConfig"
+              :available-seeing-options="availableSeeingOptions"
               @constraints-update="update"
             />
           </slot>
@@ -72,6 +73,12 @@ export default {
       type: Object,
       default: () => {
         return {};
+      }
+    },
+    availableSeeingOptions: {
+      type: Array,
+      default: () => {
+        return [];
       }
     }
   },

--- a/src/components/RequestGroupComposition/CustomSelect.vue
+++ b/src/components/RequestGroupComposition/CustomSelect.vue
@@ -1,4 +1,4 @@
- <template>
+<template>
   <span v-if="!hide">
     <span v-if="$parent.show" class="text-right font-italic extra-help-text">
       <slot name="extra-help-text" />

--- a/src/components/RequestGroupComposition/CustomSelect.vue
+++ b/src/components/RequestGroupComposition/CustomSelect.vue
@@ -1,4 +1,4 @@
-<template>
+ <template>
   <span v-if="!hide">
     <span v-if="$parent.show" class="text-right font-italic extra-help-text">
       <slot name="extra-help-text" />

--- a/src/components/RequestGroupComposition/Request.vue
+++ b/src/components/RequestGroupComposition/Request.vue
@@ -268,6 +268,7 @@
       :errors="getFromObject(errors, ['configurations', idx], {})"
       :duration-data="getFromObject(durationData, ['configurations', idx], { duration: 0 })"
       :form-config="formConfig"
+      :available-seeing-options="availableSeeingOptions"
       @remove="removeConfiguration(idx)"
       @copy="addConfiguration(idx)"
       @configuration-updated="configurationUpdated"
@@ -411,6 +412,12 @@ export default {
       type: Object,
       default: () => {
         return {};
+      }
+    },
+    availableSeeingOptions: {
+      type: Array,
+      default: () => {
+        return [];
       }
     },
     instrumentCategoryToName: {

--- a/src/components/RequestGroupComposition/RequestGroup.vue
+++ b/src/components/RequestGroupComposition/RequestGroup.vue
@@ -106,6 +106,7 @@
         :show-airmass-plot="showAirmassPlot"
         :instrument-category-to-name="instrumentCategoryToName"
         :form-config="formConfig"
+        :available-seeing-options="availableSeeingOptions"
         @remove="removeRequest(idx)"
         @copy="addRequest(idx)"
         @request-updated="requestUpdated"
@@ -214,6 +215,12 @@ export default {
       type: Object,
       default: () => {
         return {};
+      }
+    },
+    availableSeeingOptions: {
+      type: Array,
+      default: () => {
+        return [];
       }
     },
     observationTypeOptions: {

--- a/src/components/RequestGroupComposition/RequestGroupCompositionForm.vue
+++ b/src/components/RequestGroupComposition/RequestGroupCompositionForm.vue
@@ -14,6 +14,7 @@
         :show-airmass-plot="showAirmassPlot"
         :instrument-category-to-name="instrumentCategoryToName"
         :form-config="formConfig"
+        :available-seeing-options="availableSeeingOptions"
         @request-group-updated="requestGroupUpdated"
       >
         <template #request-group-help="data">
@@ -337,6 +338,12 @@ export default {
       type: Object,
       default: () => {
         return defaultTooltipConfig;
+      }
+    },
+    availableSeeingOptions: {
+      type: Array,
+      default: () => {
+        return [];
       }
     },
     // If the requestGroup prop that is passed in is associated with a draft, pass the ID in so


### PR DESCRIPTION
This plumbs the available seeing options down from the RequestGroupCompositionForm, where they're injected by whatever frontend is using it. You can see how I modified the observation-portal-frontend [here](https://github.com/LCOGT/observation-portal-frontend/compare/feature/seeing-constraint) to pass them in.

Lots of code repetition here, but that's nothing new with this big cascading compose page, I don't think. Does this seem reasonable?

This branch+obs portal frontend are running at http://observation-portal-dev.lco.gtn/