### PR TITLE
Use the default values in the cerberus schema for required fields in …

### DIFF
--- a/src/composables/baseInstrumentConfig.js
+++ b/src/composables/baseInstrumentConfig.js
@@ -56,7 +56,7 @@ export default function baseInstrumentConfig(instrumentConfig, availableInstrume
           for (let j in modes[i].validation_schema.extra_params.schema) {
             let extraParam = modes[i].validation_schema.extra_params.schema[j];
             if ('default' in extraParam) {
-              defaultValues[j] = extraParam.default
+              defaultValues[j] = extraParam.default;
             }
             requiredModeFields.push(j);
           }
@@ -87,8 +87,7 @@ export default function baseInstrumentConfig(instrumentConfig, availableInstrume
       if (rotatorModeOptions.value[i].value == instrumentConfig.value.rotator_mode) {
         if (mode in rotatorModeOptions.value[i].requiredFieldsDefaultValues) {
           return rotatorModeOptions.value[i].requiredFieldsDefaultValues[mode];
-        }
-        else {
+        } else {
           return defaultRequiredFieldValue;
         }
       }


### PR DESCRIPTION
…the rotator modes. I tested this locally to see that it shows the proper default for fields that have them set (SOAR TripleSpec instrument has a non-zero default right now).