### PR TITLE
Show error when target is not visible in the Window section

### DIFF
--- a/src/components/RequestGroupComposition/RequestGroup.vue
+++ b/src/components/RequestGroupComposition/RequestGroup.vue
@@ -24,7 +24,7 @@
             <custom-field
               v-model="requestGroup.name"
               field="name"
-              :label="getFromObject(formConfig, ['requestGroup', 'name', 'label'], 'Name')"
+              :label="getFromObject(formConfig, ['requestGroup', 'name', 'label'], 'Request Name')"
               :desc="getFromObject(formConfig, ['requestGroup', 'name', 'desc'], '')"
               :hide="getFromObject(formConfig, ['requestGroup', 'name', 'hide'], false)"
               :errors="errors.name"

--- a/src/components/RequestGroupComposition/Window.vue
+++ b/src/components/RequestGroupComposition/Window.vue
@@ -193,7 +193,12 @@ export default {
   },
   computed: {
     topLevelErrors: function() {
-      return extractTopLevelErrors(this.errors);
+      let combinedError = extractTopLevelErrors(this.errors);
+      // If showAirmass is false, it means that the airmassData is actually an error message returned from the endpoint
+      if (!this.showAirmass) {
+        combinedError = _.concat(combinedError, extractTopLevelErrors(this.airmassData));
+      }
+      return combinedError;
     }
   },
   methods: {


### PR DESCRIPTION
This is stuff Blanco requested, but I think it makes sense for everyone. Two changes:

- Renaming the label for a RequestGroup name to `Request Name` from just `Name` - I guess it was confusing since some people thought it meant a persons name should go there.
- When a target is entered and not visible, the error shows up at the Request level, and the Window section just doesn't show an Airmass Plot. This change is so that the error from the `/airmass/` endpoint is incorporated into the Window section error, so if a target is not visible, the window visibility error should show up in the Window section and at the top of the Request.